### PR TITLE
Refactor Api tests

### DIFF
--- a/CRM/RcBase/Test/BaseHeadlessTestCase.php
+++ b/CRM/RcBase/Test/BaseHeadlessTestCase.php
@@ -1,0 +1,57 @@
+<?php
+
+use Civi\Test;
+use Civi\Test\Api3DocTrait;
+use Civi\Test\ContactTestTrait;
+use Civi\Test\DbTestTrait;
+use Civi\Test\GenericAssertionsTrait;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\MailingTestTrait;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base test class for headless tests
+ * Contains helper functions for testing
+ */
+class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessInterface
+{
+    use Api3DocTrait;
+    use GenericAssertionsTrait;
+    use DbTestTrait;
+    use ContactTestTrait;
+    use MailingTestTrait;
+
+    /**
+     * The setupHeadless function runs at the start of each test case, right before
+     * the headless environment reboots.
+     *
+     * It should perform any necessary steps required for putting the database
+     * in a consistent baseline -- such as loading schema and extensions.
+     *
+     * The utility `\Civi\Test::headless()` provides a number of helper functions
+     * for managing this setup, and it includes optimizations to avoid redundant
+     * setup work.
+     *
+     * @see \Civi\Test
+     */
+    public function setUpHeadless()
+    {
+        return Test::headless()
+            ->installMe(__DIR__)
+            ->apply();
+    }
+
+    /**
+     * Apply a forced rebuild of DB, thus
+     * create a clean DB before running tests
+     *
+     * @throws CRM_Extension_Exception_ParseException
+     */
+    public static function setUpBeforeClass(): void
+    {
+        // Resets DB
+        Test::headless()
+            ->installMe(__DIR__)
+            ->apply(true);
+    }
+}

--- a/CRM/RcBase/Test/BaseHeadlessTestCase.php
+++ b/CRM/RcBase/Test/BaseHeadlessTestCase.php
@@ -176,4 +176,39 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
 
         return $result;
     }
+
+    /**
+     * Call cv api4 with create action
+     *
+     * @param string $entity Entity to work on (Contact, Email, etc.)
+     * @param array $params Params of entity
+     *
+     * @return int Created entity ID
+     *
+     * @throws CRM_Core_Exception
+     */
+    protected function cvApi4Create(string $entity, array $params = []): int
+    {
+        if (empty($entity)) {
+            throw new CRM_Core_Exception('Missing entity name');
+        }
+
+        // Parse parameters and assemble command
+        $values = [
+            'values' => $params,
+        ];
+        $values_json = json_encode($values);
+
+        $command = "api4 ${entity}.create '${values_json}'";
+
+        // Run command
+        $result = cv($command);
+
+        $this->assertIsArray($result, "Not an array returned from '${command}'");
+        $this->assertEquals(1, count($result), "Not one result returned from '${command}'");
+        $this->assertIsArray($result[0], "Not an array returned from '${command}'");
+        $this->assertArrayHasKey('id', $result[0], 'ID not found.');
+
+        return (int)$result[0]['id'];
+    }
 }

--- a/CRM/RcBase/Test/BaseHeadlessTestCase.php
+++ b/CRM/RcBase/Test/BaseHeadlessTestCase.php
@@ -102,6 +102,25 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
     }
 
     /**
+     * Sample contact parameters, next in the sequence
+     *
+     * @return array Contact parameters
+     */
+    protected function nextSampleIndividual(): array
+    {
+        // Assemble Contact data
+        $contact = $this->sampleContact('Individual', self::getNextContactSequence());
+        $contact['external_identifier'] = self::getNextExternalID();
+        // Remove unnecessary fields
+        unset($contact['prefix_id']);
+        unset($contact['suffix_id']);
+        // Remove email
+        unset($contact['email']);
+
+        return $contact;
+    }
+
+    /**
      * Call cv api4 with get action
      *
      * @param string $entity Entity to work on (Contact, Email, etc.)

--- a/CRM/RcBase/Test/BaseHeadlessTestCase.php
+++ b/CRM/RcBase/Test/BaseHeadlessTestCase.php
@@ -141,7 +141,7 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
     protected function cvApi4Get(string $entity, array $select = [], array $where = []): array
     {
         if (empty($entity)) {
-            throw new CRM_Core_Exception('Missing entity name');
+            $this->fail('Missing entity name');
         }
 
         // Parse parameters and assemble command
@@ -190,7 +190,7 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
     protected function cvApi4Create(string $entity, array $params = []): int
     {
         if (empty($entity)) {
-            throw new CRM_Core_Exception('Missing entity name');
+            $this->fail('Missing entity name');
         }
 
         // Parse parameters and assemble command

--- a/CRM/RcBase/Test/BaseHeadlessTestCase.php
+++ b/CRM/RcBase/Test/BaseHeadlessTestCase.php
@@ -29,6 +29,27 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
     protected static $externalID = 0;
 
     /**
+     * Contact sequence counter
+     *
+     * @var int
+     */
+    protected static $contactSequence = 0;
+
+    /**
+     * Apply a forced rebuild of DB, thus
+     * create a clean DB before running tests
+     *
+     * @throws CRM_Extension_Exception_ParseException
+     */
+    public static function setUpBeforeClass(): void
+    {
+        // Resets DB
+        Test::headless()
+            ->installMe(__DIR__)
+            ->apply(true);
+    }
+
+    /**
      * The setupHeadless function runs at the start of each test case, right before
      * the headless environment reboots.
      *
@@ -49,17 +70,11 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
     }
 
     /**
-     * Apply a forced rebuild of DB, thus
-     * create a clean DB before running tests
-     *
-     * @throws CRM_Extension_Exception_ParseException
+     * Setup method run before each test
      */
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
-        // Resets DB
-        Test::headless()
-            ->installMe(__DIR__)
-            ->apply(true);
+        parent::setUp();
     }
 
     /**
@@ -72,5 +87,17 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
         self::$externalID++;
 
         return (string)self::$externalID;
+    }
+
+    /**
+     * Get next contact sequence number (auto-increment)
+     *
+     * @return int Next ID
+     */
+    protected static function getNextContactSequence(): int
+    {
+        self::$contactSequence++;
+
+        return self::$contactSequence;
     }
 }

--- a/CRM/RcBase/Test/BaseHeadlessTestCase.php
+++ b/CRM/RcBase/Test/BaseHeadlessTestCase.php
@@ -22,6 +22,13 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
     use MailingTestTrait;
 
     /**
+     * External ID counter
+     *
+     * @var int
+     */
+    protected static $externalID = 0;
+
+    /**
      * The setupHeadless function runs at the start of each test case, right before
      * the headless environment reboots.
      *
@@ -53,5 +60,17 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
         Test::headless()
             ->installMe(__DIR__)
             ->apply(true);
+    }
+
+    /**
+     * Get next ID in sequence (auto-increment)
+     *
+     * @return string Next ID
+     */
+    protected static function getNextExternalID(): string
+    {
+        self::$externalID++;
+
+        return (string)self::$externalID;
     }
 }

--- a/CRM/RcBase/Test/BaseHeadlessTestCase.php
+++ b/CRM/RcBase/Test/BaseHeadlessTestCase.php
@@ -121,6 +121,47 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
     }
 
     /**
+     * Executes a raw SQL query on the DB
+     *
+     * @param string $query SQL query
+     *
+     * @return array Query results indexed by column name
+     */
+    protected function rawSqlQuery(string $query): array
+    {
+        if (empty($query)) {
+            $this->fail('Missing SQL query');
+        }
+
+        $pdo = Test::pdo();
+
+        return $pdo->query($query)->fetchAll(PDO::FETCH_ASSOC);
+
+    }
+
+    /**
+     * Get next auto-increment value for an SQL table
+     *
+     * @param string $table_name Name of table
+     *
+     * @return int Next auto-increment value
+     */
+    protected function getNextAutoIncrementValue(string $table_name): int
+    {
+        if (empty($table_name)) {
+            $this->fail('Missing table name');
+        }
+
+        $results = $this->rawSqlQuery("SHOW TABLE STATUS WHERE name='${table_name}'");
+
+        if (count($results) < 1) {
+            $this->fail("Table ${table_name} not found in DB");
+        }
+
+        return (int)$results[0]['Auto_increment'];
+    }
+
+    /**
      * Call cv api4 with get action
      *
      * @param string $entity Entity to work on (Contact, Email, etc.)

--- a/info.xml
+++ b/info.xml
@@ -16,8 +16,8 @@
         <url desc="Support">https://github.com/reflexive-communications/rc-base/issues</url>
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2021-03-25</releaseDate>
-    <version>0.2.0</version>
+    <releaseDate>2021-03-27</releaseDate>
+    <version>0.2.1</version>
     <develStage>alpha</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,8 @@
                 <!-- Skip the generated files -->
                 <file>./rc_base.php</file>
                 <file>./rc_base.civix.php</file>
+                <!-- Skip the base testcases -->
+                <directory>./CRM/RcBase/Test</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/tests/phpunit/CRM/RcBase/Api/CreateHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/CreateHeadlessTest.php
@@ -14,13 +14,6 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
      */
     private $testContactId;
 
-    /**
-     * External ID counter
-     *
-     * @var int
-     */
-    private static $externalID = 0;
-
     public function setUp(): void
     {
         parent::setUp();
@@ -42,18 +35,6 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $this->assertArrayHasKey('id', $user[0], 'ID not found.');
 
         $this->testContactId = $user[0]['id'];
-    }
-
-    /**
-     * Get next ID in sequence (auto-increment)
-     *
-     * @return string Next ID
-     */
-    private static function getNextExternalID(): string
-    {
-        self::$externalID++;
-
-        return (string)self::$externalID;
     }
 
     /**

--- a/tests/phpunit/CRM/RcBase/Api/CreateHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/CreateHeadlessTest.php
@@ -1,14 +1,11 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
-use PHPUnit\Framework\TestCase;
-
 /**
  * Test API Create class
  *
  * @group headless
  */
-class CRM_RcBase_Api_CreateHeadlessTest extends TestCase implements HeadlessInterface
+class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCase
 {
     /**
      * Test contact ID
@@ -23,39 +20,6 @@ class CRM_RcBase_Api_CreateHeadlessTest extends TestCase implements HeadlessInte
      * @var int
      */
     private static $externalID = 0;
-
-    /**
-     * The setupHeadless function runs at the start of each test case, right before
-     * the headless environment reboots.
-     *
-     * It should perform any necessary steps required for putting the database
-     * in a consistent baseline -- such as loading schema and extensions.
-     *
-     * The utility `\Civi\Test::headless()` provides a number of helper functions
-     * for managing this setup, and it includes optimizations to avoid redundant
-     * setup work.
-     *
-     * @see \Civi\Test
-     */
-    public function setUpHeadless()
-    {
-        return \Civi\Test::headless()
-            ->installMe(__DIR__)
-            ->apply();
-    }
-
-    /**
-     * Create a clean DB before running tests
-     *
-     * @throws CRM_Extension_Exception_ParseException
-     */
-    public static function setUpBeforeClass(): void
-    {
-        // Set up a clean DB
-        \Civi\Test::headless()
-            ->installMe(__DIR__)
-            ->apply(true);
-    }
 
     public function setUp(): void
     {

--- a/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
@@ -10,25 +10,6 @@ use Civi\API\Exception\UnauthorizedException;
 class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCase
 {
     /**
-     * External ID counter
-     *
-     * @var int
-     */
-    private static $externalID = 0;
-
-    /**
-     * Get next ID in sequence (auto-increment)
-     *
-     * @return string Next ID
-     */
-    private static function getNextExternalID(): string
-    {
-        self::$externalID++;
-
-        return (string)self::$externalID;
-    }
-
-    /**
      * @throws UnauthorizedException|API_Exception
      */
     public function testGetContactIdFromEmail()

--- a/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
@@ -10,105 +10,150 @@ use Civi\API\Exception\UnauthorizedException;
 class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCase
 {
     /**
-     * @throws UnauthorizedException|API_Exception
+     * @throws UnauthorizedException
+     * @throws API_Exception
+     * @throws CRM_Core_Exception
      */
     public function testGetContactIdFromEmail()
     {
-        $contact = [
-            'values' => [
-                'contact_type' => 'Individual',
-                'first_name' => 'Julius',
-                'last_name' => 'Caesar',
-            ],
+        // Create contacts
+        $contact_id_a = $this->individualCreate([], self::getNextContactSequence());
+        $contact_id_b = $this->individualCreate([], self::getNextContactSequence());
+
+        // Create emails
+        $email_a = [
+            'contact_id' => $contact_id_a,
+            'email' => 'ceasar@senate.rome',
+            'location_type_id' => 1,
         ];
-        $email = [
-            'values' => [
-                'email' => 'caesar@senate.rome',
-            ],
+        $email_id_a = $this->cvApi4Create('Email', $email_a);
+        $email_b = [
+            'contact_id' => $contact_id_a,
+            'email' => 'ceasar@home.rome',
+            'location_type_id' => 2,
         ];
-
-        // Create user & add email
-        $user = cv("api4 Contact.create '".json_encode($contact)."'");
-
-        // Check results user
-        $this->assertIsArray($user, 'Not an array returned from "cv Contact.create"');
-        $this->assertEquals(1, count($user), 'Not one result returned');
-        $this->assertIsArray($user[0], 'Not an array returned from "cv Contact.create"');
-        $this->assertArrayHasKey('id', $user[0], 'ID not found.');
-
-        $id = (int)$user[0]['id'];
-        $email['values']['contact_id'] = $id;
-        $email_results = cv("api4 Email.create '".json_encode($email)."'");
-
-        // Check results email
-        $this->assertIsArray($email_results, 'Not an array returned from "cv Contact.create"');
-        $this->assertEquals(1, count($email_results), 'Not one result returned');
-        $this->assertIsArray($email_results[0], 'Not an array returned from "cv Contact.create"');
-        $this->assertArrayHasKey('id', $email_results[0], 'ID not found.');
+        $email_id_b = $this->cvApi4Create('Email', $email_b);
+        $email_c = [
+            'contact_id' => $contact_id_b,
+            'email' => 'antonius@senate.rome',
+            'location_type_id' => 1,
+        ];
+        $email_id_c = $this->cvApi4Create('Email', $email_c);
 
         // Check valid email
         $this->assertSame(
-            $id,
-            CRM_RcBase_Api_Get::contactIDFromEmail($email['values']['email']),
+            $contact_id_a,
+            CRM_RcBase_Api_Get::contactIDFromEmail($email_a['email']),
+            'Bad contact ID returned'
+        );
+        $this->assertSame(
+            $contact_id_a,
+            CRM_RcBase_Api_Get::contactIDFromEmail($email_b['email']),
+            'Bad contact ID returned'
+        );
+        $this->assertSame(
+            $contact_id_b,
+            CRM_RcBase_Api_Get::contactIDFromEmail($email_c['email']),
             'Bad contact ID returned'
         );
 
         // Check empty email
-        $this->assertTrue(
-            is_null(CRM_RcBase_Api_Get::contactIDFromEmail("")),
-            'Not null returned on empty email'
-        );
+        $this->assertNull(CRM_RcBase_Api_Get::contactIDFromEmail(""), 'Not null returned on empty email');
 
         // Check non-existent email
-        $this->assertTrue(
-            is_null(CRM_RcBase_Api_Get::contactIDFromEmail("nonexistent@rome.com")),
+        $this->assertNull(
+            CRM_RcBase_Api_Get::contactIDFromEmail("nonexistent@rome.com"),
             'Not null returned on non-existent email'
         );
     }
 
     /**
      * @throws UnauthorizedException|API_Exception
+     * @throws CRM_Core_Exception
      */
     public function testGetContactIdFromExternalId()
     {
-        $contact = [
-            'values' => [
-                'contact_type' => 'Individual',
-                'first_name' => 'Marcus',
-                'last_name' => 'Antonius',
-                'external_identifier' => self::getNextExternalID(),
-            ],
-        ];
+        // Create contacts
+        $external_id_a = self::getNextExternalID();
+        $external_id_b = self::getNextExternalID();
 
-        // Create user
-        $user = cv("api4 Contact.create '".json_encode($contact)."'");
+        $contact_id_a = $this->individualCreate(
+            ['external_identifier' => $external_id_a],
+            self::getNextContactSequence()
+        );
+        $contact_id_b = $this->individualCreate(
+            ['external_identifier' => $external_id_b],
+            self::getNextContactSequence()
+        );
 
-        // Check results user
-        $this->assertIsArray($user, 'Not an array returned from "cv Contact.create"');
-        $this->assertEquals(1, count($user), 'Not one result returned');
-        $this->assertIsArray($user[0], 'Not an array returned from "cv Contact.create"');
-        $this->assertArrayHasKey('id', $user[0], 'ID not found.');
-
-        $id = (int)$user[0]['id'];
-
-        // Check valid external ID
+        // Check valid id
         $this->assertSame(
-            $id,
-            CRM_RcBase_Api_Get::contactIDFromExternalID($contact['values']['external_identifier']),
+            $contact_id_a,
+            CRM_RcBase_Api_Get::contactIDFromExternalID($external_id_a),
+            'Bad contact ID returned'
+        );
+        $this->assertSame(
+            $contact_id_b,
+            CRM_RcBase_Api_Get::contactIDFromExternalID($external_id_b),
             'Bad contact ID returned'
         );
 
-        // Check empty ID
-        $this->assertTrue(
-            is_null(CRM_RcBase_Api_Get::contactIDFromExternalID("")),
-            'Not null returned on empty external ID'
+        // Check empty id
+        $this->assertNull(CRM_RcBase_Api_Get::contactIDFromExternalID(""), 'Not null returned on empty email');
+
+        // Check non-existent id
+        $this->assertNull(
+            CRM_RcBase_Api_Get::contactIDFromExternalID("11-nonexistent"),
+            'Not null returned on non-existent email'
+        );
+    }
+
+    /**
+     * @throws API_Exception
+     * @throws CRM_Core_Exception
+     * @throws UnauthorizedException
+     */
+    public function testGetContactData()
+    {
+        // Create contacts
+        $external_id_a = self::getNextExternalID();
+        $external_id_b = self::getNextExternalID();
+
+        $contact_id_a = $this->individualCreate(
+            ['external_identifier' => $external_id_a],
+            self::getNextContactSequence()
+        );
+        $contact_id_b = $this->individualCreate(
+            ['external_identifier' => $external_id_b],
+            self::getNextContactSequence()
         );
 
-        // Check non-existent ID
-        $this->assertTrue(
-            is_null(CRM_RcBase_Api_Get::contactIDFromExternalID("11-nonexistent")),
-            'Not null returned on non-existent external ID'
+        // Get data
+        $data_a = $this->cvApi4Get('Contact', [], ["external_identifier=${external_id_a}"]);
+        $data_b = $this->cvApi4Get('Contact', [], ["external_identifier=${external_id_b}"]);
+
+        // Check if valid
+        $this->assertSame(
+            $data_a[0],
+            CRM_RcBase_Api_Get::contactData($contact_id_a),
+            'Invalid contact data returned on valid contact ID.'
         );
+        $this->assertSame(
+            $data_b[0],
+            CRM_RcBase_Api_Get::contactData($contact_id_b),
+            'Invalid contact data returned on valid contact ID.'
+        );
+
+        // Check for different
+        $this->assertNotSame($data_a, $data_b, 'Invalid contact data returned for different contact ID.');
+
+        // Check non-existent contact ID
+        $this->assertNull(CRM_RcBase_Api_Get::contactData(9999), 'Not null returned on non-existent contact ID');
+
+        // Check invalid ID
+        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
+        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        CRM_RcBase_Api_Get::contactData(0);
     }
 
     /**
@@ -124,147 +169,45 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
     }
 
     /**
-     * @throws API_Exception
-     * @throws CRM_Core_Exception
-     * @throws UnauthorizedException
-     */
-    public function testGetContactDataWithValidId()
-    {
-        $contact_1 = [
-            'values' => [
-                'contact_type' => 'Individual',
-                'first_name' => 'Marcus',
-                'last_name' => 'Crassus',
-                'external_identifier' => self::getNextExternalID(),
-            ],
-        ];
-        $contact_2 = [
-            'values' => [
-                'contact_type' => 'Individual',
-                'first_name' => 'Gaius',
-                'last_name' => 'Marius',
-                'external_identifier' => self::getNextExternalID(),
-            ],
-        ];
-
-        // Create users
-        $user_1 = cv("api4 Contact.create '".json_encode($contact_1)."'");
-        $user_2 = cv("api4 Contact.create '".json_encode($contact_2)."'");
-
-        // Check results user_1
-        $this->assertIsArray($user_1, 'Not an array returned from "cv Contact.create" for "user_1"');
-        $this->assertEquals(1, count($user_1), 'Not one result returned for "user_1"');
-        $this->assertIsArray($user_1[0], 'Not an array returned from "cv Contact.create" for "user_1"');
-        $this->assertArrayHasKey('id', $user_1[0], 'ID not found.');
-        // Check results user_2
-        $this->assertIsArray($user_2, 'Not an array returned from "cv Contact.create" for "user_2"');
-        $this->assertEquals(1, count($user_2), 'Not one result returned for "user_2"');
-        $this->assertIsArray($user_2[0], 'Not an array returned from "cv Contact.create" for "user_2"');
-        $this->assertArrayHasKey('id', $user_2[0], 'ID not found.');
-
-        // Get ID
-        $id_1 = $user_1[0]['id'];
-        $id_2 = $user_2[0]['id'];
-
-        // Get data
-        $data = cv("api4 Contact.get +w external_identifier=".$contact_1['values']['external_identifier']);
-
-        // Check results data
-        $this->assertIsArray($data, 'Not an array returned from "cv Contact.get" for "data"');
-        $this->assertEquals(1, count($data), 'Not one result returned for "data"');
-        $this->assertIsArray($data[0], 'Not an array returned from "cv Contact.get" for "data"');
-
-        // Check if valid
-        $this->assertSame(
-            $data[0],
-            CRM_RcBase_Api_Get::contactData($id_1),
-            'Invalid contact data returned on valid contact ID.'
-        );
-
-        // Check for different
-        $this->assertNotSame(
-            $data[0],
-            CRM_RcBase_Api_Get::contactData($id_2),
-            'Invalid contact data returned for different contact ID.'
-        );
-
-        // Check non-existent contact ID
-        $this->assertTrue(
-            is_null(CRM_RcBase_Api_Get::contactData(9999)),
-            'Not null returned on non-existent contact ID'
-        );
-
-        // Check invalid ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
-        CRM_RcBase_Api_Get::contactData(0);
-    }
-
-    /**
      * @throws UnauthorizedException|API_Exception
      * @throws CRM_Core_Exception
      */
     public function testGetEmailId()
     {
-        $contact_data = [
-            'values' => [
-                'contact_type' => 'Individual',
-                'first_name' => 'Hannibal',
-            ],
+        // Create contacts
+        $contact_id = $this->individualCreate([], self::getNextContactSequence());
+
+        // Create email
+        $email = [
+            'contact_id' => $contact_id,
+            'email' => 'hannibal@senate.carthago',
+            'location_type_id' => 3,
         ];
-        $email_data = [
-            'values' => [
-                'location_type_id' => 1,
-                'email' => 'hannibal@senate.carthago',
-            ],
-        ];
-
-        // Create user
-        $user = cv("api4 Contact.create '".json_encode($contact_data)."'");
-
-        // Check results user
-        $this->assertIsArray($user, 'Not an array returned from "cv Contact.create" for "user"');
-        $this->assertEquals(1, count($user), 'Not one result returned for "user"');
-        $this->assertIsArray($user[0], 'Not an array returned from "cv Contact.create" for "user"');
-        $this->assertArrayHasKey('id', $user[0], 'ID not found.');
-
-        $contact_id = $user[0]['id'];
-
-        // Add email
-        $email_data['values']['contact_id'] = $contact_id;
-        $email = cv("api4 Email.create '".json_encode($email_data)."'");
-
-        // Check results email
-        $this->assertIsArray($email, 'Not an array returned from "cv Email.create" for "email"');
-        $this->assertEquals(1, count($email), 'Not one result returned for "email"');
-        $this->assertIsArray($email[0], 'Not an array returned from "cv Email.create" for "email"');
-        $this->assertArrayHasKey('id', $email[0], 'ID not found.');
-
-        $email_id = $email[0]['id'];
+        $email_id = $this->cvApi4Create('Email', $email);
 
         // Check valid email
         $this->assertSame(
             $email_id,
-            CRM_RcBase_Api_Get::emailID($contact_id, $email_data['values']['location_type_id']),
+            CRM_RcBase_Api_Get::emailID($contact_id, $email['location_type_id']),
             'Bad email ID returned'
         );
 
         // Check non-existent location type
-        $this->assertTrue(
-            is_null(CRM_RcBase_Api_Get::emailID($contact_id, 5)),
+        $this->assertNull(
+            CRM_RcBase_Api_Get::emailID($contact_id, 5),
             'Not null returned on non-existent location type ID'
         );
 
         // Check non-existent contact ID
-        $this->assertTrue(
-            is_null(CRM_RcBase_Api_Get::emailID(9999, $email_data['values']['location_type_id'])),
+        $this->assertNull(
+            CRM_RcBase_Api_Get::emailID(9999, $email['location_type_id']),
             'Not null returned on non-existent contact ID'
         );
 
         // Check invalid ID
         $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
         $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
-        CRM_RcBase_Api_Get::emailID(-1, $email_data['values']['location_type_id']);
+        CRM_RcBase_Api_Get::emailID(-1, $email['location_type_id']);
     }
 
     /**
@@ -273,64 +216,40 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
      */
     public function testGetPhoneId()
     {
-        $contact_data = [
-            'values' => [
-                'contact_type' => 'Individual',
-                'first_name' => 'Augustus',
-            ],
+        // Create contacts
+        $contact_id = $this->individualCreate([], self::getNextContactSequence());
+
+        // Create phone
+        $phone = [
+            'contact_id' => $contact_id,
+            'location_type_id' => 1,
+            'phone' => '+36101234567',
         ];
-        $phone_data = [
-            'values' => [
-                'location_type_id' => 1,
-                'phone' => '+36101234567',
-            ],
-        ];
-
-        // Create user
-        $user = cv("api4 Contact.create '".json_encode($contact_data)."'");
-
-        // Check results user
-        $this->assertIsArray($user, 'Not an array returned from "cv Contact.create" for "user"');
-        $this->assertEquals(1, count($user), 'Not one result returned for "user"');
-        $this->assertIsArray($user[0], 'Not an array returned from "cv Contact.create" for "user"');
-        $this->assertArrayHasKey('id', $user[0], 'ID not found.');
-
-        $contact_id = $user[0]['id'];
-
-        // Add phone
-        $phone_data['values']['contact_id'] = $contact_id;
-        $phone = cv("api4 Phone.create '".json_encode($phone_data)."'");
-        $phone_id = $phone[0]['id'];
-
-        // Check results phone
-        $this->assertIsArray($phone, 'Not an array returned from "cv Phone.create" for "phone"');
-        $this->assertEquals(1, count($phone), 'Not one result returned for "phone"');
-        $this->assertIsArray($phone[0], 'Not an array returned from "cv Phone.create" for "phone"');
-        $this->assertArrayHasKey('id', $phone[0], 'ID not found.');
+        $phone_id = $this->cvApi4Create('Phone', $phone);
 
         // Check valid phone
         $this->assertSame(
             $phone_id,
-            CRM_RcBase_Api_Get::phoneID($contact_id, $phone_data['values']['location_type_id']),
+            CRM_RcBase_Api_Get::phoneID($contact_id, $phone['location_type_id']),
             'Bad phone ID returned'
         );
 
         // Check non-existent location type
-        $this->assertTrue(
-            is_null(CRM_RcBase_Api_Get::phoneID($contact_id, 5)),
+        $this->assertNull(
+            CRM_RcBase_Api_Get::phoneID($contact_id, 5),
             'Not null returned on non-existent location type ID'
         );
 
         // Check non-existent contact ID
-        $this->assertTrue(
-            is_null(CRM_RcBase_Api_Get::phoneID(9999, $phone_data['values']['location_type_id'])),
+        $this->assertNull(
+            CRM_RcBase_Api_Get::phoneID(9999, $phone['location_type_id']),
             'Not null returned on non-existent contact ID'
         );
 
         // Check invalid ID
         $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
         $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
-        CRM_RcBase_Api_Get::phoneID(-5, $phone_data['values']['location_type_id']);
+        CRM_RcBase_Api_Get::phoneID(-5, $phone['location_type_id']);
     }
 
     /**
@@ -339,58 +258,33 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
      */
     public function testGetAddressId()
     {
-        $contact_data = [
-            'values' => [
-                'contact_type' => 'Individual',
-                'first_name' => 'Spartacus',
-            ],
+        // Create contacts
+        $contact_id = $this->individualCreate([], self::getNextContactSequence());
+
+        // Create address
+        $address = [
+            'contact_id' => $contact_id,
+            'location_type_id' => 1,
+            'city' => 'Capua',
         ];
-        $address_data = [
-            'values' => [
-                'location_type_id' => 1,
-                'city' => 'Capua',
-            ],
-        ];
-
-        // Create user
-        $user = cv("api4 Contact.create '".json_encode($contact_data)."'");
-
-        // Check results user
-        $this->assertIsArray($user, 'Not an array returned from "cv Contact.create" for "user"');
-        $this->assertEquals(1, count($user), 'Not one result returned for "user"');
-        $this->assertIsArray($user[0], 'Not an array returned from "cv Contact.create" for "user"');
-        $this->assertArrayHasKey('id', $user[0], 'ID not found.');
-
-        $contact_id = $user[0]['id'];
-
-        // Add address
-        $address_data['values']['contact_id'] = $contact_id;
-        $address = cv("api4 Address.create '".json_encode($address_data)."'");
-
-        // Check results address
-        $this->assertIsArray($address, 'Not an array returned from "cv Address.create" for "address"');
-        $this->assertEquals(1, count($address), 'Not one result returned for "address"');
-        $this->assertIsArray($address[0], 'Not an array returned from "cv Address.create" for "address"');
-        $this->assertArrayHasKey('id', $address[0], 'ID not found.');
-
-        $address_id = $address[0]['id'];
+        $address_id = $this->cvApi4Create('Address', $address);
 
         // Check valid address
         $this->assertSame(
             $address_id,
-            CRM_RcBase_Api_Get::addressID($contact_id, $address_data['values']['location_type_id']),
+            CRM_RcBase_Api_Get::addressID($contact_id, $address['location_type_id']),
             'Bad address ID returned'
         );
 
         // Check non-existent location type
-        $this->assertTrue(
-            is_null(CRM_RcBase_Api_Get::addressID($contact_id, 5)),
+        $this->assertNull(
+            CRM_RcBase_Api_Get::addressID($contact_id, 5),
             'Not null returned on non-existent location type ID'
         );
 
         // Check non-existent contact ID
-        $this->assertTrue(
-            is_null(CRM_RcBase_Api_Get::addressID(9999, $address_data['values']['location_type_id'])),
+        $this->assertNull(
+            CRM_RcBase_Api_Get::addressID(9999, $address['location_type_id']),
             'Not null returned on non-existent contact ID'
         );
 
@@ -406,60 +300,17 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
      */
     public function testGetRelationshipId()
     {
-        $contact = [
-            'values' => [
-                'contact_type' => 'Individual',
-                'first_name' => 'Romulus',
-                'external_identifier' => self::getNextExternalID(),
-            ],
+        // Create contacts
+        $contact_id = $this->individualCreate([], self::getNextContactSequence());
+        $contact_id_other = $this->individualCreate([], self::getNextContactSequence());
+
+        // Create relationship
+        $relationship = [
+            'contact_id_a' => $contact_id,
+            'contact_id_b' => $contact_id_other,
+            'relationship_type_id' => 1,
         ];
-        $contact_other = [
-            'values' => [
-                'contact_type' => 'Individual',
-                'first_name' => 'Remus',
-                'external_identifier' => self::getNextExternalID(),
-            ],
-        ];
-        $relationship_data = [
-            'values' => [
-                'relationship_type_id' => 1,
-            ],
-        ];
-
-        // Create users
-        $user = cv("api4 Contact.create '".json_encode($contact)."'");
-        $user_other = cv("api4 Contact.create '".json_encode($contact_other)."'");
-
-        // Check results user
-        $this->assertIsArray($user, 'Not an array returned from "cv Contact.create" for "user"');
-        $this->assertEquals(1, count($user), 'Not one result returned for "user"');
-        $this->assertIsArray($user[0], 'Not an array returned from "cv Contact.create" for "user"');
-        $this->assertArrayHasKey('id', $user[0], 'ID not found.');
-
-        // Check results user_other
-        $this->assertIsArray($user_other, 'Not an array returned from "cv Contact.create" for "user_other"');
-        $this->assertEquals(1, count($user_other), 'Not one result returned for "user_other"');
-        $this->assertIsArray($user_other[0], 'Not an array returned from "cv Contact.create" for "user_other"');
-        $this->assertArrayHasKey('id', $user_other[0], 'ID not found.');
-
-        $contact_id = $user[0]['id'];
-        $contact_id_other = $user_other[0]['id'];
-
-        // Add relationship
-        $relationship_data['values']['contact_id_a'] = $contact_id;
-        $relationship_data['values']['contact_id_b'] = $contact_id_other;
-        $relationship = cv("api4 Relationship.create '".json_encode($relationship_data)."'");
-
-        // Check results address
-        $this->assertIsArray($relationship, 'Not an array returned from "cv Relationship.create" for "relationship"');
-        $this->assertEquals(1, count($relationship), 'Not one result returned for "relationship"');
-        $this->assertIsArray(
-            $relationship[0],
-            'Not an array returned from "cv Relationship.create" for "relationship"'
-        );
-        $this->assertArrayHasKey('id', $relationship[0], 'ID not found.');
-
-        $relationship_id = $relationship[0]['id'];
+        $relationship_id = $this->cvApi4Create('Relationship', $relationship);
 
         // Check valid relationship
         $this->assertSame(
@@ -467,33 +318,27 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
             CRM_RcBase_Api_Get::relationshipID(
                 $contact_id,
                 $contact_id_other,
-                $relationship_data['values']['relationship_type_id']
+                $relationship['relationship_type_id']
             ),
             'Bad relationship ID returned'
         );
 
         // Check non-existent relationship type
-        $this->assertTrue(
-            is_null(CRM_RcBase_Api_Get::relationshipID($contact_id, $contact_id, 5)),
+        $this->assertNull(
+            CRM_RcBase_Api_Get::relationshipID($contact_id, $contact_id, 5),
             'Not null returned on non-existent relationship type ID'
         );
 
         // Check non-existent contact ID
-        $this->assertTrue(
-            is_null(
-                CRM_RcBase_Api_Get::relationshipID(
-                    9999,
-                    $contact_id_other,
-                    $relationship_data['values']['relationship_type_id']
-                )
-            ),
+        $this->assertNull(
+            CRM_RcBase_Api_Get::relationshipID(9999, $contact_id_other, $relationship['relationship_type_id']),
             'Not null returned on non-existent contact ID'
         );
 
         // Check invalid ID
         $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
         $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
-        CRM_RcBase_Api_Get::relationshipID($contact_id, $contact_id, -5);
+        CRM_RcBase_Api_Get::relationshipID($contact_id, $contact_id_other, -5);
     }
 
     /**
@@ -517,121 +362,43 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
      */
     public function testGetAllActivity()
     {
-        $contact_source_a = [
-            'values' => [
-                'contact_type' => 'Individual',
-                'first_name' => 'Tiberius',
-            ],
-        ];
-        $contact_source_b = [
-            'values' => [
-                'contact_type' => 'Individual',
-                'first_name' => 'Claudius',
-            ],
-        ];
-        $contact_target = [
-            'values' => [
-                'contact_type' => 'Individual',
-                'first_name' => 'Nero',
-            ],
-        ];
-        $contact_assignee_a = [
-            'values' => [
-                'contact_type' => 'Individual',
-                'first_name' => 'Caligula',
-            ],
-        ];
-        $contact_assignee_b = [
-            'values' => [
-                'contact_type' => 'Individual',
-                'first_name' => 'Agrippa',
-            ],
-        ];
-        $activity_data_a = [
-            'values' => [
-                'activity_type_id' => 1,
-            ],
-        ];
-        $activity_data_b = [
-            'values' => [
-                'activity_type_id' => 2,
-            ],
-        ];
-
-        // Create users
-        $user_source_a = cv("api4 Contact.create '".json_encode($contact_source_a)."'");
-        $user_source_b = cv("api4 Contact.create '".json_encode($contact_source_b)."'");
-        $user_target = cv("api4 Contact.create '".json_encode($contact_target)."'");
-        $user_assignee_a = cv("api4 Contact.create '".json_encode($contact_assignee_a)."'");
-        $user_assignee_b = cv("api4 Contact.create '".json_encode($contact_assignee_b)."'");
-
-        // Check results user_source_a
-        $this->assertIsArray($user_source_a, 'Not an array returned from "cv Contact.create" for "user_source_a"');
-        $this->assertEquals(1, count($user_source_a), 'Not one result returned for "user_source_a"');
-        $this->assertIsArray($user_source_a[0], 'Not an array returned from "cv Contact.create" for "user_source_a"');
-        $this->assertArrayHasKey('id', $user_source_a[0], 'ID not found.');
-
-        // Check results user_source_b
-        $this->assertIsArray($user_source_b, 'Not an array returned from "cv Contact.create" for "user_source_b"');
-        $this->assertEquals(1, count($user_source_b), 'Not one result returned for "user_source_b"');
-        $this->assertIsArray($user_source_b[0], 'Not an array returned from "cv Contact.create" for "user_source_b"');
-        $this->assertArrayHasKey('id', $user_source_b[0], 'ID not found.');
-
-        // Check results user_target
-        $this->assertIsArray($user_target, 'Not an array returned from "cv Contact.create" for "user_target"');
-        $this->assertEquals(1, count($user_target), 'Not one result returned for "user_target"');
-        $this->assertIsArray($user_target[0], 'Not an array returned from "cv Contact.create" for "user_target"');
-        $this->assertArrayHasKey('id', $user_target[0], 'ID not found.');
-
-        // Check results user_assignee_a
-        $this->assertIsArray($user_assignee_a, 'Not an array returned from "cv Contact.create" for "user_assignee_a"');
-        $this->assertEquals(1, count($user_assignee_a), 'Not one result returned for "user_assignee_a"');
-        $this->assertIsArray(
-            $user_assignee_a[0],
-            'Not an array returned from "cv Contact.create" for "user_assignee_a"'
-        );
-        $this->assertArrayHasKey('id', $user_assignee_a[0], 'ID not found.');
-
-        // Check results user_assignee_b
-        $this->assertIsArray($user_assignee_b, 'Not an array returned from "cv Contact.create" for "user_assignee_b"');
-        $this->assertEquals(1, count($user_assignee_b), 'Not one result returned for "user_assignee_b"');
-        $this->assertIsArray(
-            $user_assignee_b[0],
-            'Not an array returned from "cv Contact.create" for "user_assignee_b"'
-        );
-        $this->assertArrayHasKey('id', $user_assignee_b[0], 'ID not found.');
-
-        $contact_id_source_a = $user_source_a[0]['id'];
-        $contact_id_source_b = $user_source_b[0]['id'];
-        $contact_id_target = $user_target[0]['id'];
-        $contact_id_assignee_a = $user_assignee_a[0]['id'];
-        $contact_id_assignee_b = $user_assignee_b[0]['id'];
+        // Create contacts
+        $contact_id_source_a = $this->individualCreate([], self::getNextContactSequence());
+        $contact_id_source_b = $this->individualCreate([], self::getNextContactSequence());
+        $contact_id_target = $this->individualCreate([], self::getNextContactSequence());
+        $contact_id_assignee_a = $this->individualCreate([], self::getNextContactSequence());
+        $contact_id_assignee_b = $this->individualCreate([], self::getNextContactSequence());
 
         // Add activities
-        $activity_data_a['values']['source_contact_id'] = $contact_id_source_a;
-        $activity_data_a['values']['target_contact_id'] = $contact_id_target;
-        $activity_data_a['values']['assignee_contact_id'] = $contact_id_assignee_a;
-        $activity_data_b['values']['source_contact_id'] = $contact_id_source_a;
-        $activity_data_b['values']['target_contact_id'] = $contact_id_target;
-        $activity_data_b['values']['assignee_contact_id'] = $contact_id_assignee_a;
+        $activity_a = [
+            'activity_type_id' => 1,
+            'source_contact_id' => $contact_id_source_a,
+            'target_contact_id' => $contact_id_target,
+            'assignee_contact_id' => $contact_id_assignee_a,
+            ];
+        $activity_b = [
+            'activity_type_id' => 2,
+            'source_contact_id' => $contact_id_source_a,
+            'target_contact_id' => $contact_id_target,
+            'assignee_contact_id' => $contact_id_assignee_a,
+            ];
 
-        cv("api4 Activity.create '".json_encode($activity_data_a)."'");
-        cv("api4 Activity.create '".json_encode($activity_data_a)."'");
-        cv("api4 Activity.create '".json_encode($activity_data_b)."'");
-        cv("api4 Activity.create '".json_encode($activity_data_b)."'");
-        cv("api4 Activity.create '".json_encode($activity_data_b)."'");
+        $this->cvApi4Create('Activity', $activity_a);
+        $this->cvApi4Create('Activity', $activity_a);
+        $this->cvApi4Create('Activity', $activity_b);
+        $this->cvApi4Create('Activity', $activity_b);
+        $this->cvApi4Create('Activity', $activity_b);
 
-        $activity_data_a['values']['source_contact_id'] = $contact_id_source_b;
-        $activity_data_a['values']['target_contact_id'] = $contact_id_target;
-        $activity_data_a['values']['assignee_contact_id'] = $contact_id_assignee_b;
-        $activity_data_b['values']['source_contact_id'] = $contact_id_source_a;
-        $activity_data_b['values']['target_contact_id'] = $contact_id_target;
-        $activity_data_b['values']['assignee_contact_id'] = $contact_id_assignee_b;
+        // Add other activities
+        $activity_a['source_contact_id'] = $contact_id_source_b;
+        $activity_a['assignee_contact_id'] = $contact_id_assignee_b;
 
-        cv("api4 Activity.create '".json_encode($activity_data_a)."'");
-        cv("api4 Activity.create '".json_encode($activity_data_b)."'");
-        cv("api4 Activity.create '".json_encode($activity_data_b)."'");
-        cv("api4 Activity.create '".json_encode($activity_data_b)."'");
+        $activity_b['assignee_contact_id'] = $contact_id_assignee_b;
+
+        $this->cvApi4Create('Activity', $activity_a);
+        $this->cvApi4Create('Activity', $activity_b);
+        $this->cvApi4Create('Activity', $activity_b);
+        $this->cvApi4Create('Activity', $activity_b);
 
         // Check activities when contact is target
         $activities = CRM_RcBase_Api_Get::allActivity(
@@ -644,7 +411,7 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
         $activities = CRM_RcBase_Api_Get::allActivity(
             $contact_id_target,
             CRM_RcBase_Api_Get::ACTIVITY_RECORD_TYPE_TARGET,
-            $activity_data_b['values']['activity_type_id']
+            $activity_b['activity_type_id']
         );
         $this->assertCount(6, $activities, 'Bad number of filtered activities when contact is the target');
 
@@ -670,7 +437,7 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
         $activities = CRM_RcBase_Api_Get::allActivity(
             $contact_id_assignee_b,
             CRM_RcBase_Api_Get::ACTIVITY_RECORD_TYPE_ASSIGNEE,
-            $activity_data_a['values']['activity_type_id']
+            $activity_a['activity_type_id']
         );
         $this->assertCount(1, $activities, 'Bad number of activities when contact is the assignee');
 

--- a/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
@@ -148,7 +148,10 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
         $this->assertNotSame($data_a, $data_b, 'Invalid contact data returned for different contact ID.');
 
         // Check non-existent contact ID
-        $this->assertNull(CRM_RcBase_Api_Get::contactData(9999), 'Not null returned on non-existent contact ID');
+        $this->assertNull(
+            CRM_RcBase_Api_Get::contactData($this->getNextAutoIncrementValue('civicrm_contact')),
+            'Not null returned on non-existent contact ID'
+        );
 
         // Check invalid ID
         $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
@@ -200,7 +203,10 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
 
         // Check non-existent contact ID
         $this->assertNull(
-            CRM_RcBase_Api_Get::emailID(9999, $email['location_type_id']),
+            CRM_RcBase_Api_Get::emailID(
+                $this->getNextAutoIncrementValue('civicrm_contact'),
+                $email['location_type_id']
+            ),
             'Not null returned on non-existent contact ID'
         );
 
@@ -242,7 +248,10 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
 
         // Check non-existent contact ID
         $this->assertNull(
-            CRM_RcBase_Api_Get::phoneID(9999, $phone['location_type_id']),
+            CRM_RcBase_Api_Get::phoneID(
+                $this->getNextAutoIncrementValue('civicrm_contact'),
+                $phone['location_type_id']
+            ),
             'Not null returned on non-existent contact ID'
         );
 
@@ -284,7 +293,10 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
 
         // Check non-existent contact ID
         $this->assertNull(
-            CRM_RcBase_Api_Get::addressID(9999, $address['location_type_id']),
+            CRM_RcBase_Api_Get::addressID(
+                $this->getNextAutoIncrementValue('civicrm_contact'),
+                $address['location_type_id']
+            ),
             'Not null returned on non-existent contact ID'
         );
 
@@ -331,7 +343,11 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
 
         // Check non-existent contact ID
         $this->assertNull(
-            CRM_RcBase_Api_Get::relationshipID(9999, $contact_id_other, $relationship['relationship_type_id']),
+            CRM_RcBase_Api_Get::relationshipID(
+                $this->getNextAutoIncrementValue('civicrm_contact'),
+                $contact_id_other,
+                $relationship['relationship_type_id']
+            ),
             'Not null returned on non-existent contact ID'
         );
 
@@ -375,13 +391,13 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
             'source_contact_id' => $contact_id_source_a,
             'target_contact_id' => $contact_id_target,
             'assignee_contact_id' => $contact_id_assignee_a,
-            ];
+        ];
         $activity_b = [
             'activity_type_id' => 2,
             'source_contact_id' => $contact_id_source_a,
             'target_contact_id' => $contact_id_target,
             'assignee_contact_id' => $contact_id_assignee_a,
-            ];
+        ];
 
         $this->cvApi4Create('Activity', $activity_a);
         $this->cvApi4Create('Activity', $activity_a);

--- a/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
@@ -1,17 +1,13 @@
 <?php
 
 use Civi\API\Exception\UnauthorizedException;
-use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
-use Civi\Test\TransactionalInterface;
-use PHPUnit\Framework\TestCase;
 
 /**
  * Test API Get class
  *
  * @group headless
  */
-class CRM_RcBase_Api_GetHeadlessTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
+class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCase
 {
     /**
      * External ID counter
@@ -19,39 +15,6 @@ class CRM_RcBase_Api_GetHeadlessTest extends TestCase implements HeadlessInterfa
      * @var int
      */
     private static $externalID = 0;
-
-    /**
-     * The setupHeadless function runs at the start of each test case, right before
-     * the headless environment reboots.
-     *
-     * It should perform any necessary steps required for putting the database
-     * in a consistent baseline -- such as loading schema and extensions.
-     *
-     * The utility `\Civi\Test::headless()` provides a number of helper functions
-     * for managing this setup, and it includes optimizations to avoid redundant
-     * setup work.
-     *
-     * @see \Civi\Test
-     */
-    public function setUpHeadless()
-    {
-        return \Civi\Test::headless()
-            ->installMe(__DIR__)
-            ->apply();
-    }
-
-    /**
-     * Create a clean DB before running tests
-     *
-     * @throws CRM_Extension_Exception_ParseException
-     */
-    public static function setUpBeforeClass(): void
-    {
-        // Set up a clean DB
-        \Civi\Test::headless()
-            ->installMe(__DIR__)
-            ->apply(true);
-    }
 
     /**
      * Get next ID in sequence (auto-increment)

--- a/tests/phpunit/CRM/RcBase/Api/UpdateHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/UpdateHeadlessTest.php
@@ -1,14 +1,11 @@
 <?php
 
-use Civi\Test\HeadlessInterface;
-use PHPUnit\Framework\TestCase;
-
 /**
  * Test API Update class
  *
  * @group headless
  */
-class CRM_RcBase_Api_UpdateHeadlessTest extends TestCase implements HeadlessInterface
+class CRM_RcBase_Api_UpdateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCase
 {
     /**
      * Test contact ID
@@ -23,39 +20,6 @@ class CRM_RcBase_Api_UpdateHeadlessTest extends TestCase implements HeadlessInte
      * @var int
      */
     private static $externalID = 0;
-
-    /**
-     * The setupHeadless function runs at the start of each test case, right before
-     * the headless environment reboots.
-     *
-     * It should perform any necessary steps required for putting the database
-     * in a consistent baseline -- such as loading schema and extensions.
-     *
-     * The utility `\Civi\Test::headless()` provides a number of helper functions
-     * for managing this setup, and it includes optimizations to avoid redundant
-     * setup work.
-     *
-     * @see \Civi\Test
-     */
-    public function setUpHeadless()
-    {
-        return \Civi\Test::headless()
-            ->installMe(__DIR__)
-            ->apply();
-    }
-
-    /**
-     * Create a clean DB before running tests
-     *
-     * @throws CRM_Extension_Exception_ParseException
-     */
-    public static function setUpBeforeClass(): void
-    {
-        // Set up a clean DB
-        \Civi\Test::headless()
-            ->installMe(__DIR__)
-            ->apply(true);
-    }
 
     public function setUp(): void
     {

--- a/tests/phpunit/CRM/RcBase/Api/UpdateHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/UpdateHeadlessTest.php
@@ -14,13 +14,6 @@ class CRM_RcBase_Api_UpdateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
      */
     private $testContactId;
 
-    /**
-     * External ID counter
-     *
-     * @var int
-     */
-    private static $externalID = 0;
-
     public function setUp(): void
     {
         parent::setUp();
@@ -35,18 +28,6 @@ class CRM_RcBase_Api_UpdateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         ];
         $user = cv("api4 Contact.create '".json_encode($contact_data)."'");
         $this->testContactId = (int)$user[0]['id'];
-    }
-
-    /**
-     * Get next ID in sequence (auto-increment)
-     *
-     * @return string Next ID
-     */
-    private static function getNextExternalID(): string
-    {
-        self::$externalID++;
-
-        return (string)self::$externalID;
     }
 
     /**


### PR DESCRIPTION
Refactor Api Headless tests

- create new Base Headless TestCase class for helper methods
    - wrappers for `cv`
    - counters for external ID, contact sequence
    - implement `Headless interface`
    - use extra test traits
- use ContactTestTrait to simplify test setup
- Testing: check number of records currently in DB before and after a create or update action
