### PR TITLE
Config

### DIFF
--- a/CRM/RcBase/Config.php
+++ b/CRM/RcBase/Config.php
@@ -1,0 +1,102 @@
+<?php
+
+abstract class CRM_RcBase_Config {
+
+    private $configName;
+    private $configuration;
+
+    /**
+     * CRM_RcBase_Config constructor.
+     *
+     * @param string $extensionName prefix for db.
+     */
+    public function __construct(string $extensionName) {
+        $this->configName = $extensionName."_configuration";
+        $this->configuration = $this->defaultConfiguration();
+    }
+
+    /**
+     * Provides a default configuration object.
+     *
+     * @return array the default configuration object.
+     */
+    abstract public function defaultConfiguration(): array;
+
+    /**
+     * Creates configuration table in db.
+     *
+     * @return bool the status of the db write process.
+     */
+    public function create(): bool {
+        Civi::settings()->add([$this->configName => $this->configuration]);
+        // check the save process with loading the saved content and compare
+        // it with the current configuration
+        $saved = Civi::settings()->get($this->configName);
+        return $saved === $this->configuration;
+    }
+
+    /**
+     * Removes configuration table from db.
+     *
+     * @return bool the status of the deletion process.
+     */
+    public function remove(): bool {
+        Civi::settings()->revert($this->configName);
+        // check the deletion process with loading the saved content and compare
+        // it with null.
+        $saved = Civi::settings()->get($this->configName);
+        if (is_null($saved)) {
+            // cleanup the class config
+            $this->configuration = null;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Loads configuration from db.
+     *
+     * @throws CRM_Core_Exception.
+     */
+    public function load(): void {
+        $conf = Civi::settings()->get($this->configName);
+        // if not loaded well, it throws exception.
+        if (is_null($conf) || !is_array($conf)) {
+            throw new CRM_Core_Exception($this->configName." config invalid.");
+        }
+        $this->configuration = $conf;
+    }
+
+    /**
+     * Updates the configuration in db.
+     *
+     * @param array $newConfig the updated config to save
+     *
+     * @return bool the status of the update process.
+     */
+    public function update(array $newConfig): bool {
+        Civi::settings()->set($this->configName, $newConfig);
+        // check the save process with loading the saved content and compare
+        // it with the newConfig configuration
+        $saved = Civi::settings()->get($this->configName);
+        if ($saved === $newConfig) {
+            $this->configuration = $newConfig;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns the configuration.
+     *
+     * @return array the configuration.
+     *
+     * @throws CRM_Core_Exception.
+     */
+    public function get(): array {
+        if (is_null($this->configuration)) {
+            throw new CRM_Core_Exception($this->configName." config is missing.");
+        }
+        return $this->configuration;
+    }
+}

--- a/CRM/RcBase/Config.php
+++ b/CRM/RcBase/Config.php
@@ -11,7 +11,7 @@ abstract class CRM_RcBase_Config {
      * @param string $extensionName prefix for db.
      */
     public function __construct(string $extensionName) {
-        $this->configName = $extensionName."_configuration";
+        $this->configName = $extensionName."_config";
         $this->configuration = $this->defaultConfiguration();
     }
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,47 @@ This extension does nothing, it is only required by some other extensions. It co
 
 The extension is licensed under [AGPL-3.0](LICENSE.txt).
 
+### Config aka. CRM\_RcBase\_Config
+
+This abstract class provides an interface for the db methods (civi config). The create, load, update, get, remove methods are implemented in this class. If you want to use this Config, you have to extend this class and implement the defaultConfiguration method. It is responsible for providing an extension specific default configuration that will be inserted to the settings database with the create method. The configuration is stored under a config specific key in the settings db. The prefix of this key has to be passed to the class constructor. The default configuration is inserted to the config database on extension install.
+
+**Concrete implementation example**
+
+```php
+class CRM_MyExtension_MyConfig extends CRM_RcBase_Config {
+    public function defaultConfiguration(): array {
+        return [
+            "important-key" => 1,
+        ];
+    }
+}
+```
+
+**Get current configuration**
+
+```php
+$config = new CRM_MyExtension_MyConfig("MyExtension_Key_Prefix");
+try {
+    $config->load();
+} catch (Exception $e) {
+    // It could happen if the dbhost is not configured well.
+}
+$configuration = $config->get();
+```
+
+**Update configuration**
+
+```php
+$config = new CRM_MyExtension_MyConfig("MyExtension_Key_Prefix");
+$newConfig = [
+    "important-key" => 2,
+    "new-key" => "Some new value",
+];
+if (!$config->update($newConfig)) {
+    // It could happen if the dbhost is not configured well.
+}
+```
+
 ## Requirements
 
 * PHP v7.3+

--- a/info.xml
+++ b/info.xml
@@ -17,7 +17,7 @@
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
     <releaseDate>2021-03-25</releaseDate>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
     <develStage>alpha</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/tests/phpunit/CRM/RcBase/ConfigHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/ConfigHeadlessTest.php
@@ -79,6 +79,31 @@ class CRM_RcBase_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implemen
         self::assertSame(DEFAULT_CONFIGURATION, $cfg, "Invalid configuration has been returned.");
         self::assertTrue($config->create(), "Create config has to be successful multiple times.");
     }
+    public function testCreateAfterChanges() {
+        $config = $this->getConfig();
+        self::assertTrue($config->create(), "Create config has to be successful.");
+        $cfg = $config->get();
+        self::assertSame(DEFAULT_CONFIGURATION, $cfg, "Invalid configuration has been returned.");
+        self::assertTrue($config->create(), "Create config has to be successful multiple times.");
+        // Update config and call create. The updated config has to be created.
+        foreach ($cfg as $k => $v) {
+            $newKey = $k."new";
+            unset($cfg[$k]);
+            $cfg[$newKey] = $v;
+            $cfg[$newKey."v2"] = false;
+            break;
+        }
+        self::assertTrue($config->update($cfg), "Update config has to be successful.");
+        self::assertEmpty($config->load(), "Load result supposed to be empty.");
+        self::assertTrue($config->create(), "Create config has to be successful with changed config.");
+        $cfgNew = $config->get();
+        self::assertSame($cfg, $cfgNew, "Invalid configuration has been returned.");
+        // reset the changes with creating the db with a new config instance.
+        $otherConfig = $this->getConfig();
+        self::assertTrue($otherConfig->create(), "Create config has to be successful.");
+        $otherCfg = $otherConfig->get();
+        self::assertSame(DEFAULT_CONFIGURATION, $otherCfg, "Invalid configuration has been returned.");
+    }
 
     /**
      * It checks that the remove function works well.
@@ -114,6 +139,13 @@ class CRM_RcBase_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implemen
         // preset the config.
         Civi::settings()->add([CONFIG_NAME => DEFAULT_CONFIGURATION]);
         $cfg = Civi::settings()->get(CONFIG_NAME);
+        foreach ($cfg as $k => $v) {
+            $newKey = $k."new";
+            unset($cfg[$k]);
+            $cfg[$newKey] = $v;
+            $cfg[$newKey."v2"] = false;
+            break;
+        }
         $cfg["brand-new-key"] = false;
         self::assertTrue($config->update($cfg), "Update config has to be successful.");
         self::assertSame($cfg, $config->get(), "Invalid updated configuration.");

--- a/tests/phpunit/CRM/RcBase/ConfigHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/ConfigHeadlessTest.php
@@ -127,7 +127,7 @@ class CRM_RcBase_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implemen
         // remove the config
         self::assertTrue($config->remove(), "Remove config has to be successful.");
         self::expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        self::expectExceptionMessage(CONFIG_NAME."_configuration config is missing.", "Invalid exception message.");
+        self::expectExceptionMessage(CONFIG_NAME."_config config is missing.", "Invalid exception message.");
         $config->get();
     }
 
@@ -157,7 +157,7 @@ class CRM_RcBase_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implemen
     public function testLoadEmptyConfig() {
         $config = $this->getConfig();
         self::expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        self::expectExceptionMessage(CONFIG_NAME."_configuration config invalid.", "Invalid exception message.");
+        self::expectExceptionMessage(CONFIG_NAME."_config config invalid.", "Invalid exception message.");
         self::assertEmpty($config->load(), "Load result supposed to be empty.");
     }
     public function testLoadCreatedConfig() {

--- a/tests/phpunit/CRM/RcBase/ConfigHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/ConfigHeadlessTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use CRM_RcBase_ExtensionUtil as E;
+use Civi\Test;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+const DEFAULT_CONFIGURATION = [
+    "Key1" => "value1",
+    "Key2" => 12,
+    "Key3" => true,
+    "Key4" => [],
+    "Key5" => [ "SubKey" => "Great success!", ],
+];
+const CONFIG_NAME = "rcBase_test";
+
+class TestConfig extends CRM_RcBase_Config {
+    public function defaultConfiguration(): array {
+        return DEFAULT_CONFIGURATION;
+    }
+}
+/**
+ * Config class test cases.
+ * It tests the testConfig class that extends from the config and implements the 
+ * defaultConfiguration method.
+ *
+ * @group headless
+ */
+class CRM_RcBase_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface {
+
+
+    public function setUpHeadless() {
+        return Test::headless()
+            ->installMe(__DIR__)
+            ->apply();
+    }
+    /**
+     * Create a clean DB before running tests
+     *
+     * @throws CRM_Extension_Exception_ParseException
+     */
+    public static function setUpBeforeClass(): void {
+        Test::headless()
+            ->installMe(__DIR__)
+            ->apply(true);
+    }
+    /**
+     * Create a clean DB before running tests
+     *
+     * @throws CRM_Extension_Exception_ParseException
+     */
+    public static function tearDownAfterClass(): void {
+        Test::headless()
+            ->uninstallMe(__DIR__)
+            ->apply(true);
+    }
+
+    public function setUp(): void {
+        parent::setUp();
+    }
+
+    public function tearDown(): void {
+        $this->getConfig()->remove();
+        parent::tearDown();
+    }
+
+    private function getConfig() {
+        return new TestConfig(CONFIG_NAME);
+    }
+
+    /**
+     * It checks that the create function works well.
+     */
+    public function testCreate() {
+        $config = $this->getConfig();
+        self::assertTrue($config->create(), "Create config has to be successful.");
+        $cfg = $config->get();
+        self::assertSame(DEFAULT_CONFIGURATION, $cfg, "Invalid configuration has been returned.");
+        self::assertTrue($config->create(), "Create config has to be successful multiple times.");
+    }
+
+    /**
+     * It checks that the remove function works well.
+     */
+    public function testRemove() {
+        $config = $this->getConfig();
+        // preset the config.
+        Civi::settings()->add([CONFIG_NAME => DEFAULT_CONFIGURATION]);
+        self::assertTrue($config->remove(), "Remove config has to be successful.");
+    }
+
+    /**
+     * It checks that the get function works well.
+     */
+    public function testGet() {
+        $config = $this->getConfig();
+        // preset the config.
+        Civi::settings()->add([CONFIG_NAME =>DEFAULT_CONFIGURATION]);
+        self::assertSame(DEFAULT_CONFIGURATION, $config->get(), "Invalid configuration has been returned.");
+
+        // remove the config
+        self::assertTrue($config->remove(), "Remove config has to be successful.");
+        self::expectException(CRM_Core_Exception::class, "Invalid exception class.");
+        self::expectExceptionMessage(CONFIG_NAME."_configuration config is missing.", "Invalid exception message.");
+        $config->get();
+    }
+
+    /**
+     * It checks that the update function works well.
+     */
+    public function testUpdate() {
+        $config = $this->getConfig();
+        // preset the config.
+        Civi::settings()->add([CONFIG_NAME => DEFAULT_CONFIGURATION]);
+        $cfg = Civi::settings()->get(CONFIG_NAME);
+        $cfg["brand-new-key"] = false;
+        self::assertTrue($config->update($cfg), "Update config has to be successful.");
+        self::assertSame($cfg, $config->get(), "Invalid updated configuration.");
+    }
+
+    /**
+     * It checks that the get function works well.
+     */
+    public function testLoadEmptyConfig() {
+        $config = $this->getConfig();
+        self::expectException(CRM_Core_Exception::class, "Invalid exception class.");
+        self::expectExceptionMessage(CONFIG_NAME."_configuration config invalid.", "Invalid exception message.");
+        self::assertEmpty($config->load(), "Load result supposed to be empty.");
+    }
+    public function testLoadCreatedConfig() {
+        $config = $this->getConfig();
+        // preset the config.
+        $config->create();
+        self::assertEmpty($config->load(), "Load result supposed to be empty.");
+        $cfg = $config->get();
+        self::assertEquals(DEFAULT_CONFIGURATION, $cfg, "Invalid loaded configuration.");
+        // update the config
+        $cfg["brand-new-key"] = false;
+        self::assertTrue($config->update($cfg), "Update config has to be successful.");
+        self::assertEmpty($config->load(), "Load result supposed to be empty.");
+        self::assertSame($cfg, $config->get(), "Invalid loaded configuration.");
+    }
+}


### PR DESCRIPTION
The main logic of the config has been added to this repo.
Open question:
- Config db name. Now it it the extension name suffixed with the "_configuration" string. In [wrapi](https://github.com/reflexive-communications/wrapi/blob/main/CRM/Wrapi/ConfigManager.php#L15) it is suffixed with "_config", In [civalpa](https://github.com/reflexive-communications/civalpa/blob/main/CRM/Civalpa/Config.php#L16) it is suffixed with "_rules". In [webhooks](https://github.com/reflexive-communications/hu.es-progress.webhook/blob/main/CRM/Webhook/Config.php#L19) it is the same.

As we decided, we will use the "_config" suffix.