### PR TITLE
New API methods for handling tags

### DIFF
--- a/CRM/RcBase/Api/Create.php
+++ b/CRM/RcBase/Api/Create.php
@@ -187,4 +187,30 @@ class CRM_RcBase_Api_Create
 
         return self::entity('Activity', $values, $check_permissions);
     }
+
+    /**
+     * Add tag to contact
+     *
+     * @param int $contact_id Contact ID
+     * @param int $tag_id Tag ID
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return int EntityTag ID
+     *
+     * @throws CRM_Core_Exception
+     */
+    public static function tagContact(int $contact_id, int $tag_id, bool $check_permissions = false)
+    {
+        if ($contact_id < 1 || $tag_id < 1) {
+            throw new CRM_Core_Exception('Invalid ID.');
+        }
+
+        $values = [
+            'entity_table' => 'civicrm_contact',
+            'entity_id' => $contact_id,
+            'tag_id' => $tag_id,
+        ];
+
+        return self::entity('EntityTag', $values, $check_permissions);
+    }
 }

--- a/CRM/RcBase/Api/Create.php
+++ b/CRM/RcBase/Api/Create.php
@@ -33,7 +33,7 @@ class CRM_RcBase_Api_Create
                     'checkPermissions' => $check_permissions,
                 ]
             );
-        } catch (\Throwable $ex) {
+        } catch (Throwable $ex) {
             throw new CRM_Core_Exception(sprintf('Failed to create %s, reason: %s', $entity, $ex->getMessage()));
         }
 

--- a/CRM/RcBase/Api/Create.php
+++ b/CRM/RcBase/Api/Create.php
@@ -199,7 +199,7 @@ class CRM_RcBase_Api_Create
      *
      * @throws CRM_Core_Exception
      */
-    public static function tagContact(int $contact_id, int $tag_id, bool $check_permissions = false)
+    public static function tagContact(int $contact_id, int $tag_id, bool $check_permissions = false): int
     {
         if ($contact_id < 1 || $tag_id < 1) {
             throw new CRM_Core_Exception('Invalid ID.');

--- a/CRM/RcBase/Api/Get.php
+++ b/CRM/RcBase/Api/Get.php
@@ -5,6 +5,7 @@ use Civi\Api4\ActivityContact;
 use Civi\Api4\Address;
 use Civi\Api4\Contact;
 use Civi\Api4\Email;
+use Civi\Api4\EntityTag;
 use Civi\Api4\Generic\Result;
 use Civi\Api4\LocationType;
 use Civi\Api4\Phone;
@@ -330,5 +331,35 @@ class CRM_RcBase_Api_Get
         }
 
         return $activities;
+    }
+
+    /**
+     * Check if tag is applied to a contact
+     *
+     * @param int $contact_id Contact ID
+     * @param int $tag_id Tag ID
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return int|null EntityTag ID if found, null if not found
+     *
+     * @throws API_Exception
+     * @throws CRM_Core_Exception
+     * @throws UnauthorizedException
+     */
+    public static function contactHasTag(int $contact_id, int $tag_id, bool $check_permissions = false): ?int
+    {
+        if ($contact_id < 1 || $tag_id < 1) {
+            throw new CRM_Core_Exception('Invalid ID.');
+        }
+
+        $results = EntityTag::get($check_permissions)
+            ->addSelect('id')
+            ->addWhere('entity_id', '=', $contact_id)
+            ->addWhere('entity_table', '=', 'civicrm_contact')
+            ->addWhere('tag_id', '=', $tag_id)
+            ->setLimit(1)
+            ->execute();
+
+        return self::parseResultsFirst($results, 'id');
     }
 }

--- a/CRM/RcBase/Api/Get.php
+++ b/CRM/RcBase/Api/Get.php
@@ -45,7 +45,7 @@ class CRM_RcBase_Api_Get
      *
      * @return mixed|null
      */
-    protected static function parseResultsFirst(Result $results, string $field = "")
+    protected static function parseResultsFirst(Result $results, string $field = '')
     {
         // Get first result row
         $result = $results->first();

--- a/CRM/RcBase/Api/Save.php
+++ b/CRM/RcBase/Api/Save.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Common Save Actions
+ *
+ * Wrapper around APIv4
+ *
+ * @package  rc-base
+ * @author   Sandor Semsey <sandor@es-progress.hu>
+ * @license  AGPL-3.0
+ */
+class CRM_RcBase_Api_Save
+{
+    /**
+     * Add tag to contact
+     * Check if contact is already tagged before tagging
+     *
+     * @param int $contact_id Contact ID
+     * @param int $tag_id Tag ID
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return int Entity tag ID
+     *
+     * @throws \API_Exception
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\API\Exception\UnauthorizedException
+     */
+    public static function tagContact(int $contact_id, int $tag_id, bool $check_permissions = false): ?int
+    {
+        $entity_tag_id = CRM_RcBase_Api_Get::contactHasTag($contact_id, $tag_id, $check_permissions);
+
+        // Already has tag
+        if ($entity_tag_id) {
+            return null;
+        }
+
+        // No tag present --> tag contact
+        return CRM_RcBase_Api_Create::tagContact($contact_id, $tag_id, $check_permissions);
+    }
+}

--- a/CRM/RcBase/Api/Update.php
+++ b/CRM/RcBase/Api/Update.php
@@ -48,7 +48,7 @@ class CRM_RcBase_Api_Update
                 ]
             );
 
-        } catch (\Throwable $ex) {
+        } catch (Throwable $ex) {
             throw new CRM_Core_Exception(sprintf('Failed to update %s, reason: %s', $entity, $ex->getMessage()));
         }
 

--- a/CRM/RcBase/Processor/Base.php
+++ b/CRM/RcBase/Processor/Base.php
@@ -129,7 +129,7 @@ class CRM_RcBase_Processor_Base
         }
 
         // Empty value
-        if ($value === "" || $value === [] || $value === null) {
+        if ($value === '' || $value === [] || $value === null) {
             if ($required) {
                 throw new CRM_Core_Exception(sprintf('Missing parameter: %s', $name));
             }

--- a/CRM/RcBase/Processor/XML.php
+++ b/CRM/RcBase/Processor/XML.php
@@ -25,7 +25,7 @@ class CRM_RcBase_Processor_XML
         // Disable external entity parsing to prevent XXE attack
         // In libxml versions from 2.9.0 XXE is disabled by default
         if (LIBXML_VERSION < 20900) {
-            libxml_disable_entity_loader(true);
+            libxml_disable_entity_loader();
         }
 
         try {

--- a/CRM/RcBase/Test/BaseHeadlessTestCase.php
+++ b/CRM/RcBase/Test/BaseHeadlessTestCase.php
@@ -176,8 +176,6 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
      *                          ]
      *
      * @return array Results
-     *
-     * @throws CRM_Core_Exception
      */
     protected function cvApi4Get(string $entity, array $select = [], array $where = []): array
     {
@@ -203,15 +201,21 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
         $result = cv($command);
 
         // Check results
-        $this->assertIsArray($result, "Not an array returned from '${command}'");
+        if (!is_array($result)) {
+            $this->fail("Not an array returned from '${command}'");
+        }
 
         // Check each record
         foreach ($result as $record) {
-            $this->assertIsArray($record, "Not an array returned from '${command}'");
+            if (!is_array($result)) {
+                $this->fail("Not an array returned from '${command}'");
+            }
 
             // Check if selected fields are present
             foreach ($select as $item) {
-                $this->assertArrayHasKey($item, $record, "${item} not returned");
+                if (!array_key_exists($item, $record)) {
+                    $this->fail("${item} not returned");
+                }
             }
         }
 
@@ -225,8 +229,6 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
      * @param  array   $params  Params of entity
      *
      * @return int Created entity ID
-     *
-     * @throws CRM_Core_Exception
      */
     protected function cvApi4Create(string $entity, array $params = []): int
     {
@@ -245,10 +247,19 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
         // Run command
         $result = cv($command);
 
-        $this->assertIsArray($result, "Not an array returned from '${command}'");
-        $this->assertEquals(1, count($result), "Not one result returned from '${command}'");
-        $this->assertIsArray($result[0], "Not an array returned from '${command}'");
-        $this->assertArrayHasKey('id', $result[0], 'ID not found.');
+        // Check results
+        if (!is_array($result)) {
+            $this->fail("Not an array returned from '${command}'");
+        }
+        if (count($result) != 1) {
+            $this->fail("Not one result returned from '${command}'");
+        }
+        if (!is_array($result[0])) {
+            $this->fail("Not an array returned from '${command}'");
+        }
+        if (!array_key_exists('id', $result[0])) {
+            $this->fail('ID not found.');
+        }
 
         return (int)$result[0]['id'];
     }

--- a/CRM/RcBase/Test/BaseHeadlessTestCase.php
+++ b/CRM/RcBase/Test/BaseHeadlessTestCase.php
@@ -194,7 +194,7 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
 
         $where_string = '';
         foreach ($where as $item) {
-            $where_string .= "+w '${item}'";
+            $where_string .= "+w '${item}' ";
         }
 
         $command = "api4 ${entity}.get ${select_string} ${where_string}";

--- a/info.xml
+++ b/info.xml
@@ -16,8 +16,8 @@
         <url desc="Support">https://github.com/reflexive-communications/rc-base/issues</url>
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2021-04-01</releaseDate>
-    <version>0.4.0</version>
+    <releaseDate>2021-04-06</releaseDate>
+    <version>0.5.0</version>
     <develStage>alpha</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
@@ -197,7 +197,7 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
 
         // Check non-existent location type
         $this->assertNull(
-            CRM_RcBase_Api_Get::emailID($contact_id, 5),
+            CRM_RcBase_Api_Get::emailID($contact_id, $this->getNextAutoIncrementValue('civicrm_location_type')),
             'Not null returned on non-existent location type ID'
         );
 
@@ -242,7 +242,7 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
 
         // Check non-existent location type
         $this->assertNull(
-            CRM_RcBase_Api_Get::phoneID($contact_id, 5),
+            CRM_RcBase_Api_Get::phoneID($contact_id, $this->getNextAutoIncrementValue('civicrm_location_type')),
             'Not null returned on non-existent location type ID'
         );
 
@@ -287,7 +287,7 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
 
         // Check non-existent location type
         $this->assertNull(
-            CRM_RcBase_Api_Get::addressID($contact_id, 5),
+            CRM_RcBase_Api_Get::addressID($contact_id, $this->getNextAutoIncrementValue('civicrm_location_type')),
             'Not null returned on non-existent location type ID'
         );
 
@@ -337,7 +337,7 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
 
         // Check non-existent relationship type
         $this->assertNull(
-            CRM_RcBase_Api_Get::relationshipID($contact_id, $contact_id, 5),
+            CRM_RcBase_Api_Get::relationshipID($contact_id, $contact_id, $this->getNextAutoIncrementValue('civicrm_relationship_type')),
             'Not null returned on non-existent relationship type ID'
         );
 

--- a/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
@@ -462,4 +462,55 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
         $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
         CRM_RcBase_Api_Get::allActivity($contact_id_target, 5, -5);
     }
+
+    /**
+     * @throws UnauthorizedException|API_Exception
+     * @throws CRM_Core_Exception
+     */
+    public function testContactHasTag()
+    {
+        // Create contact
+        $contact_id = $this->individualCreate([], self::getNextContactSequence());
+
+        // Create tag
+        $tag = [
+            'name' => 'Test tag',
+        ];
+        $tag_id = $this->cvApi4Create('Tag', $tag);
+
+        // Add tag to contact
+        $entity_tag = [
+            'entity_table' => 'civicrm_contact',
+            'entity_id' => $contact_id,
+            'tag_id' => $tag_id,
+        ];
+        $entity_tag_id = $this->cvApi4Create('EntityTag', $entity_tag);
+
+        // Check valid tag
+        $this->assertSame(
+            $entity_tag_id,
+            CRM_RcBase_Api_Get::contactHasTag($contact_id, $tag_id),
+            'Bad entity tag ID returned'
+        );
+
+        // Check non-existent tag
+        $this->assertNull(
+            CRM_RcBase_Api_Get::contactHasTag($contact_id, $this->getNextAutoIncrementValue('civicrm_tag')),
+            'Not null returned on non-existent tag'
+        );
+
+        // Check non-existent contact ID
+        $this->assertNull(
+            CRM_RcBase_Api_Get::contactHasTag(
+                $this->getNextAutoIncrementValue('civicrm_contact'),
+                $tag_id
+            ),
+            'Not null returned on non-existent contact ID'
+        );
+
+        // Check invalid ID
+        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
+        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        CRM_RcBase_Api_Get::contactHasTag(-1, $tag_id);
+    }
 }

--- a/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
@@ -433,7 +433,7 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
 
         // Check non-existent activities returned
         $activities = CRM_RcBase_Api_Get::allActivity($contact_id_target, 5);
-        $this->assertCount(0, $activities, 'Non existent activites returned');
+        $this->assertCount(0, $activities, 'Non existent activities returned');
 
         // Check activities when contact is source
         $activities = CRM_RcBase_Api_Get::allActivity(

--- a/tests/phpunit/CRM/RcBase/Api/SaveHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/SaveHeadlessTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Test API Save class
+ *
+ * @group headless
+ */
+class CRM_RcBase_Api_SaveHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCase
+{
+    /**
+     * @throws CRM_Core_Exception
+     */
+    public function testSaveTagWithNotTaggedContact()
+    {
+        // Create contact
+        $contact_id = $this->individualCreate([], self::getNextContactSequence());
+
+        // Create tag
+        $tag = [
+            'name' => 'Test tag',
+        ];
+        $tag_id = $this->cvApi4Create('Tag', $tag);
+
+        // Number of entity tags already in DB
+        $all_entity_tag_old = $this->cvApi4Get('EntityTag', ['id']);
+
+        // Save tag to contact
+        $entity_tag_id = CRM_RcBase_Api_Save::tagContact($contact_id, $tag_id);
+
+        $all_entity_tag_new = $this->cvApi4Get('EntityTag', ['id']);
+
+        $this->assertCount(
+            count($all_entity_tag_old) + 1,
+            $all_entity_tag_new,
+            'No new entity tag created'
+        );
+
+        // Get from DB
+        $id = $this->cvApi4Get('EntityTag', ['id'], [
+            'entity_table=civicrm_contact',
+            "entity_id=${contact_id}",
+            "tag_id=${tag_id}",
+        ]);
+        $this->assertCount(1, $id, 'Not one result returned for "id"');
+
+        // Check valid ID
+        $this->assertSame($id[0]['id'], $entity_tag_id, 'Bad entity tag ID returned');
+    }
+
+    /**
+     * @throws CRM_Core_Exception
+     */
+    public function testSaveTagWithTaggedContact()
+    {
+        // Create contact
+        $contact_id = $this->individualCreate([], self::getNextContactSequence());
+
+        // Create tag
+        $tag = [
+            'name' => 'Another test tag',
+        ];
+        $tag_id = $this->cvApi4Create('Tag', $tag);
+
+        // Add tag to contact
+        $entity_tag = [
+            'entity_table' => 'civicrm_contact',
+            'entity_id' => $contact_id,
+            'tag_id' => $tag_id,
+        ];
+        $entity_tag_id = $this->cvApi4Create('EntityTag', $entity_tag);
+
+        // Number of entity tags already in DB
+        $all_entity_tag_old = $this->cvApi4Get('EntityTag', ['id']);
+
+        // Save tag to contact
+        $entity_tag_id_save = CRM_RcBase_Api_Save::tagContact($contact_id, $tag_id);
+
+        $all_entity_tag_new = $this->cvApi4Get('EntityTag', ['id']);
+
+        $this->assertCount(
+            count($all_entity_tag_old),
+            $all_entity_tag_new,
+            'Additional entity tag created'
+        );
+        // Check valid ID
+        $this->assertNull($entity_tag_id_save, 'Not null returned when no tagging was needed');
+    }
+}

--- a/tests/phpunit/CRM/RcBase/Api/SaveHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/SaveHeadlessTest.php
@@ -8,7 +8,9 @@
 class CRM_RcBase_Api_SaveHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCase
 {
     /**
-     * @throws CRM_Core_Exception
+     * @throws \API_Exception
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\API\Exception\UnauthorizedException
      */
     public function testSaveTagWithNotTaggedContact()
     {
@@ -48,7 +50,9 @@ class CRM_RcBase_Api_SaveHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCa
     }
 
     /**
-     * @throws CRM_Core_Exception
+     * @throws \API_Exception
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\API\Exception\UnauthorizedException
      */
     public function testSaveTagWithTaggedContact()
     {


### PR DESCRIPTION
New methods in API:
- `Create::tagContact()`
- `Get::contactHasTag()`

Minor changes:
- `cvApi4Get`: fix where array parsing
- `cvApi4`: change assert to fail
- get non-existent ID dynamically from DB