### PR TITLE
Format

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   code-style:
-    name:    Code style check with PHP-CS-Fixer
+    name:    Code style check
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,18 @@ env:
   PHP_VERSION:         7.3
 
 jobs:
-  tests:
+  code-style:
+    name:    Code style check with PHP-CS-Fixer
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: PHP-CS-Fixer
+        uses: docker://oskarstark/php-cs-fixer-ga
+        with:
+          args: --config=.php_cs.dist --dry-run -v
+  unit-tests:
     name:    Unit tests
+    needs:   code-style
     runs-on: ubuntu-18.04
     services:
       mysql:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
         uses: docker://oskarstark/php-cs-fixer-ga
         with:
           args: --config=.php_cs.dist --dry-run -v
+
   unit-tests:
     name:    Unit tests
     needs:   code-style

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,11 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__);
+
+$config = new PhpCsFixer\Config();
+return $config->setRules([
+    '@PSR2' => true,
+])
+    ->setFinder($finder)
+    ->setCacheFile(__DIR__.'/.php_cs.cache');

--- a/CRM/RcBase/Api/Get.php
+++ b/CRM/RcBase/Api/Get.php
@@ -251,7 +251,6 @@ class CRM_RcBase_Api_Get
         int $relationship_type_id,
         bool $check_permissions = false
     ): ?int {
-
         if ($contact_id < 1 || $other_contact_id < 1 || $relationship_type_id < 1) {
             throw new CRM_Core_Exception('Invalid ID.');
         }

--- a/CRM/RcBase/Api/Update.php
+++ b/CRM/RcBase/Api/Update.php
@@ -29,7 +29,6 @@ class CRM_RcBase_Api_Update
         array $values = [],
         bool $check_permissions = false
     ): array {
-
         if ($entity_id < 1) {
             throw new CRM_Core_Exception('Invalid ID.');
         }
@@ -47,7 +46,6 @@ class CRM_RcBase_Api_Update
                     'checkPermissions' => $check_permissions,
                 ]
             );
-
         } catch (Throwable $ex) {
             throw new CRM_Core_Exception(sprintf('Failed to update %s, reason: %s', $entity, $ex->getMessage()));
         }

--- a/CRM/RcBase/Config.php
+++ b/CRM/RcBase/Config.php
@@ -1,8 +1,9 @@
 <?php
 
-abstract class CRM_RcBase_Config {
-
+abstract class CRM_RcBase_Config
+{
     private $configName;
+
     private $configuration;
 
     /**
@@ -10,8 +11,9 @@ abstract class CRM_RcBase_Config {
      *
      * @param string $extensionName prefix for db.
      */
-    public function __construct(string $extensionName) {
-        $this->configName = $extensionName."_config";
+    public function __construct(string $extensionName)
+    {
+        $this->configName = $extensionName.'_config';
         $this->configuration = $this->defaultConfiguration();
     }
 
@@ -27,7 +29,8 @@ abstract class CRM_RcBase_Config {
      *
      * @return bool the status of the db write process.
      */
-    public function create(): bool {
+    public function create(): bool
+    {
         Civi::settings()->add([$this->configName => $this->configuration]);
         // check the save process with loading the saved content and compare
         // it with the current configuration
@@ -40,7 +43,8 @@ abstract class CRM_RcBase_Config {
      *
      * @return bool the status of the deletion process.
      */
-    public function remove(): bool {
+    public function remove(): bool
+    {
         Civi::settings()->revert($this->configName);
         // check the deletion process with loading the saved content and compare
         // it with null.
@@ -58,11 +62,12 @@ abstract class CRM_RcBase_Config {
      *
      * @throws CRM_Core_Exception.
      */
-    public function load(): void {
+    public function load(): void
+    {
         $conf = Civi::settings()->get($this->configName);
         // if not loaded well, it throws exception.
         if (is_null($conf) || !is_array($conf)) {
-            throw new CRM_Core_Exception($this->configName." config invalid.");
+            throw new CRM_Core_Exception($this->configName.' config invalid.');
         }
         $this->configuration = $conf;
     }
@@ -74,7 +79,8 @@ abstract class CRM_RcBase_Config {
      *
      * @return bool the status of the update process.
      */
-    public function update(array $newConfig): bool {
+    public function update(array $newConfig): bool
+    {
         Civi::settings()->set($this->configName, $newConfig);
         // check the save process with loading the saved content and compare
         // it with the newConfig configuration
@@ -93,9 +99,10 @@ abstract class CRM_RcBase_Config {
      *
      * @throws CRM_Core_Exception.
      */
-    public function get(): array {
+    public function get(): array
+    {
         if (is_null($this->configuration)) {
-            throw new CRM_Core_Exception($this->configName." config is missing.");
+            throw new CRM_Core_Exception($this->configName.' config is missing.');
         }
         return $this->configuration;
     }

--- a/CRM/RcBase/Processor/Base.php
+++ b/CRM/RcBase/Processor/Base.php
@@ -39,7 +39,7 @@ class CRM_RcBase_Processor_Base
     /**
      * Perform basic input sanitization
      *
-     * @param  mixed  $input  Input to sanitize
+     * @param mixed $input Input to sanitize
      *
      * @return mixed Sanitized input
      */
@@ -71,7 +71,7 @@ class CRM_RcBase_Processor_Base
     /**
      * Sanitize string
      *
-     * @param  mixed  $value  Value to sanitize
+     * @param mixed $value Value to sanitize
      *
      * @return string Sanitized string
      */
@@ -94,20 +94,20 @@ class CRM_RcBase_Processor_Base
      * Throws exception if problem with input
      * No exception means input OK
      *
-     * @param  mixed   $value           Input to validate
-     * @param  string  $type            Input type
-     *                                  'string':   any string
-     *                                  'email':    email address
-     *                                  'int':      integer
-     *                                  'id':       positive integer
-     *                                  'float':    float
-     *                                  'bool':     boolean
-     *                                  'date':     date
-     *                                  'datetime': datetime
-     * @param  string  $name            Name of variable (for logging and reporting)
-     * @param  bool    $required        Is value required?
-     *                                  throws exception if value is empty
-     * @param  array   $allowed_values  Allowed values for this input
+     * @param mixed $value Input to validate
+     * @param string $type Input type
+     *  'string':   any string
+     *  'email':    email address
+     *  'int':      integer
+     *  'id':       positive integer
+     *  'float':    float
+     *  'bool':     boolean
+     *  'date':     date
+     *  'datetime': datetime
+     * @param string $name Name of variable (for logging and reporting)
+     * @param bool $required Is value required?
+     *                       throws exception if value is empty
+     * @param array $allowed_values Allowed values for this input
      *
      * @return void
      *
@@ -180,5 +180,4 @@ class CRM_RcBase_Processor_Base
             throw new CRM_Core_Exception(sprintf('Not allowed value for: %s (%s)', $name, $value));
         }
     }
-
 }

--- a/CRM/RcBase/Processor/Config.php
+++ b/CRM/RcBase/Processor/Config.php
@@ -10,13 +10,12 @@
  */
 class CRM_RcBase_Processor_Config
 {
-
     /**
      * Parse INI string
      *
-     * @param  string  $ini_string        INI string to parse
-     * @param  bool    $process_sections  Process sections
-     * @param  int     $scanner_mode      Scanner mode
+     * @param string $ini_string INI string to parse
+     * @param bool $process_sections Process sections
+     * @param int $scanner_mode Scanner mode
      *
      * @return mixed Parsed config
      *
@@ -39,9 +38,9 @@ class CRM_RcBase_Processor_Config
     /**
      * Parse INI file
      *
-     * @param  string  $filename          INI file to parse
-     * @param  bool    $process_sections  Process sections
-     * @param  int     $scanner_mode      Scanner mode
+     * @param string $filename INI file to parse
+     * @param bool $process_sections Process sections
+     * @param int $scanner_mode Scanner mode
      *
      * @return mixed Parsed config
      *
@@ -60,5 +59,4 @@ class CRM_RcBase_Processor_Config
             throw new CRM_Core_Exception('Failed to parse ini file'.$ex->getMessage());
         }
     }
-
 }

--- a/CRM/RcBase/Processor/JSON.php
+++ b/CRM/RcBase/Processor/JSON.php
@@ -9,11 +9,10 @@
  */
 class CRM_RcBase_Processor_JSON
 {
-
     /**
      * Parse JSON string
      *
-     * @param  string  $json  JSON to parse
+     * @param string $json JSON to parse
      *
      * @return mixed Parsed JSON object
      *
@@ -42,7 +41,7 @@ class CRM_RcBase_Processor_JSON
      *
      * @link https://www.php.net/manual/en/wrappers.expect.php
      *
-     * @param  string  $stream  Name of JSON stream
+     * @param string $stream Name of JSON stream
      *
      * @return mixed Parsed data
      *
@@ -75,7 +74,7 @@ class CRM_RcBase_Processor_JSON
     /**
      * Encode data to JSON
      *
-     * @param  mixed  $data  Object to encode
+     * @param mixed $data Object to encode
      *
      * @return mixed JSON
      */
@@ -83,5 +82,4 @@ class CRM_RcBase_Processor_JSON
     {
         return json_encode($data, JSON_UNESCAPED_UNICODE);
     }
-
 }

--- a/CRM/RcBase/Processor/UrlEncodedForm.php
+++ b/CRM/RcBase/Processor/UrlEncodedForm.php
@@ -39,5 +39,4 @@ class CRM_RcBase_Processor_UrlEncodedForm
     {
         return CRM_RcBase_Processor_Base::sanitize($_REQUEST);
     }
-
 }

--- a/CRM/RcBase/Processor/XML.php
+++ b/CRM/RcBase/Processor/XML.php
@@ -13,8 +13,8 @@ class CRM_RcBase_Processor_XML
     /**
      * Parse XML string
      *
-     * @param  string  $xml_string    XML to parse
-     * @param  bool    $return_array  Return array or SimpleXMLElement
+     * @param string $xml_string XML to parse
+     * @param bool $return_array Return array or SimpleXMLElement
      *
      * @return mixed Parsed XML object
      *
@@ -57,7 +57,7 @@ class CRM_RcBase_Processor_XML
      *
      * @link https://www.php.net/manual/en/wrappers.expect.php
      *
-     * @param  string  $stream  Name of XML stream
+     * @param string $stream Name of XML stream
      *
      * @return mixed Parsed data
      *
@@ -86,5 +86,4 @@ class CRM_RcBase_Processor_XML
     {
         return self::parseStream('php://input');
     }
-
 }

--- a/CRM/RcBase/Test/BaseHeadlessTestCase.php
+++ b/CRM/RcBase/Test/BaseHeadlessTestCase.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
  */
 class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessInterface
 {
-
     use Api3DocTrait;
     use GenericAssertionsTrait;
     use DbTestTrait;
@@ -124,7 +123,7 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
     /**
      * Executes a raw SQL query on the DB
      *
-     * @param  string  $query  SQL query
+     * @param string $query SQL query
      *
      * @return array Query results indexed by column name
      */
@@ -142,7 +141,7 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
     /**
      * Get next auto-increment value for an SQL table
      *
-     * @param  string  $table_name  Name of table
+     * @param string $table_name Name of table
      *
      * @return int Next auto-increment value
      */
@@ -164,16 +163,16 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
     /**
      * Call cv api4 with get action
      *
-     * @param  string  $entity  Entity to work on (Contact, Email, etc.)
-     * @param  array   $select  Fields to return
-     *                          Example:
-     *                          $select = ['contact_type', 'first_name', 'external_identifier']
-     * @param  array   $where   Where conditions to filter results (if more given they are joined by AND)
-     *                          Example:
-     *                          $where = [
-     *                          'contact_type=Individual',
-     *                          'first_name like "Adams%",
-     *                          ]
+     * @param string $entity Entity to work on (Contact, Email, etc.)
+     * @param array $select Fields to return
+     *   Example:
+     *   $select = ['contact_type', 'first_name', 'external_identifier']
+     * @param array $where Where conditions to filter results (if more given they are joined by AND)
+     *   Example:
+     *   $where = [
+     *   'contact_type=Individual',
+     *   'first_name like "Adams%",
+     *   ]
      *
      * @return array Results
      */
@@ -225,8 +224,8 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
     /**
      * Call cv api4 with create action
      *
-     * @param  string  $entity  Entity to work on (Contact, Email, etc.)
-     * @param  array   $params  Params of entity
+     * @param string $entity Entity to work on (Contact, Email, etc.)
+     * @param array $params Params of entity
      *
      * @return int Created entity ID
      */
@@ -263,5 +262,4 @@ class CRM_RcBase_Test_BaseHeadlessTestCase extends TestCase implements HeadlessI
 
         return (int)$result[0]['id'];
     }
-
 }

--- a/CRM/RcBase/Test/MockPhpStream.php
+++ b/CRM/RcBase/Test/MockPhpStream.php
@@ -18,7 +18,6 @@
  */
 class CRM_RcBase_Test_MockPhpStream
 {
-
     protected $index = 0;
 
     protected $length = null;
@@ -93,5 +92,4 @@ class CRM_RcBase_Test_MockPhpStream
         $this->index = 0;
         $this->length = 0;
     }
-
 }

--- a/info.xml
+++ b/info.xml
@@ -17,7 +17,7 @@
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
     <releaseDate>2021-04-06</releaseDate>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
     <develStage>alpha</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/rc_base.civix.php
+++ b/rc_base.civix.php
@@ -6,75 +6,79 @@
  * The ExtensionUtil class provides small stubs for accessing resources of this
  * extension.
  */
-class CRM_RcBase_ExtensionUtil {
-  const SHORT_NAME = 'rc_base';
-  const LONG_NAME = 'rc-base';
-  const CLASS_PREFIX = 'CRM_RcBase';
+class CRM_RcBase_ExtensionUtil
+{
+    const SHORT_NAME = 'rc_base';
+    const LONG_NAME = 'rc-base';
+    const CLASS_PREFIX = 'CRM_RcBase';
 
-  /**
-   * Translate a string using the extension's domain.
-   *
-   * If the extension doesn't have a specific translation
-   * for the string, fallback to the default translations.
-   *
-   * @param string $text
-   *   Canonical message text (generally en_US).
-   * @param array $params
-   * @return string
-   *   Translated text.
-   * @see ts
-   */
-  public static function ts($text, $params = []) {
-    if (!array_key_exists('domain', $params)) {
-      $params['domain'] = [self::LONG_NAME, NULL];
+    /**
+     * Translate a string using the extension's domain.
+     *
+     * If the extension doesn't have a specific translation
+     * for the string, fallback to the default translations.
+     *
+     * @param string $text
+     *   Canonical message text (generally en_US).
+     * @param array $params
+     * @return string
+     *   Translated text.
+     * @see ts
+     */
+    public static function ts($text, $params = [])
+    {
+        if (!array_key_exists('domain', $params)) {
+            $params['domain'] = [self::LONG_NAME, null];
+        }
+        return ts($text, $params);
     }
-    return ts($text, $params);
-  }
 
-  /**
-   * Get the URL of a resource file (in this extension).
-   *
-   * @param string|NULL $file
-   *   Ex: NULL.
-   *   Ex: 'css/foo.css'.
-   * @return string
-   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
-   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
-   */
-  public static function url($file = NULL) {
-    if ($file === NULL) {
-      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    /**
+     * Get the URL of a resource file (in this extension).
+     *
+     * @param string|NULL $file
+     *   Ex: NULL.
+     *   Ex: 'css/foo.css'.
+     * @return string
+     *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+     *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+     */
+    public static function url($file = null)
+    {
+        if ($file === null) {
+            return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+        }
+        return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
     }
-    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
-  }
 
-  /**
-   * Get the path of a resource file (in this extension).
-   *
-   * @param string|NULL $file
-   *   Ex: NULL.
-   *   Ex: 'css/foo.css'.
-   * @return string
-   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
-   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
-   */
-  public static function path($file = NULL) {
-    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
-    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
-  }
+    /**
+     * Get the path of a resource file (in this extension).
+     *
+     * @param string|NULL $file
+     *   Ex: NULL.
+     *   Ex: 'css/foo.css'.
+     * @return string
+     *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+     *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+     */
+    public static function path($file = null)
+    {
+        // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+        return __DIR__ . ($file === null ? '' : (DIRECTORY_SEPARATOR . $file));
+    }
 
-  /**
-   * Get the name of a class within this extension.
-   *
-   * @param string $suffix
-   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
-   * @return string
-   *   Ex: 'CRM_Foo_Page_HelloWorld'.
-   */
-  public static function findClass($suffix) {
-    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
-  }
-
+    /**
+     * Get the name of a class within this extension.
+     *
+     * @param string $suffix
+     *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+     * @return string
+     *   Ex: 'CRM_Foo_Page_HelloWorld'.
+     */
+    public static function findClass($suffix)
+    {
+        return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+    }
 }
 
 use CRM_RcBase_ExtensionUtil as E;
@@ -84,27 +88,27 @@ use CRM_RcBase_ExtensionUtil as E;
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
-function _rc_base_civix_civicrm_config(&$config = NULL) {
-  static $configured = FALSE;
-  if ($configured) {
-    return;
-  }
-  $configured = TRUE;
+function _rc_base_civix_civicrm_config(&$config = null)
+{
+    static $configured = false;
+    if ($configured) {
+        return;
+    }
+    $configured = true;
 
-  $template =& CRM_Core_Smarty::singleton();
+    $template =& CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
-  $extDir = $extRoot . 'templates';
+    $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+    $extDir = $extRoot . 'templates';
 
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = [$extDir, $template->template_dir];
-  }
+    if (is_array($template->template_dir)) {
+        array_unshift($template->template_dir, $extDir);
+    } else {
+        $template->template_dir = [$extDir, $template->template_dir];
+    }
 
-  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
-  set_include_path($include_path);
+    $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+    set_include_path($include_path);
 }
 
 /**
@@ -114,10 +118,11 @@ function _rc_base_civix_civicrm_config(&$config = NULL) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
  */
-function _rc_base_civix_civicrm_xmlMenu(&$files) {
-  foreach (_rc_base_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
-    $files[] = $file;
-  }
+function _rc_base_civix_civicrm_xmlMenu(&$files)
+{
+    foreach (_rc_base_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
+        $files[] = $file;
+    }
 }
 
 /**
@@ -125,11 +130,12 @@ function _rc_base_civix_civicrm_xmlMenu(&$files) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
-function _rc_base_civix_civicrm_install() {
-  _rc_base_civix_civicrm_config();
-  if ($upgrader = _rc_base_civix_upgrader()) {
-    $upgrader->onInstall();
-  }
+function _rc_base_civix_civicrm_install()
+{
+    _rc_base_civix_civicrm_config();
+    if ($upgrader = _rc_base_civix_upgrader()) {
+        $upgrader->onInstall();
+    }
 }
 
 /**
@@ -137,13 +143,14 @@ function _rc_base_civix_civicrm_install() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
  */
-function _rc_base_civix_civicrm_postInstall() {
-  _rc_base_civix_civicrm_config();
-  if ($upgrader = _rc_base_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onPostInstall'])) {
-      $upgrader->onPostInstall();
+function _rc_base_civix_civicrm_postInstall()
+{
+    _rc_base_civix_civicrm_config();
+    if ($upgrader = _rc_base_civix_upgrader()) {
+        if (is_callable([$upgrader, 'onPostInstall'])) {
+            $upgrader->onPostInstall();
+        }
     }
-  }
 }
 
 /**
@@ -151,11 +158,12 @@ function _rc_base_civix_civicrm_postInstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
-function _rc_base_civix_civicrm_uninstall() {
-  _rc_base_civix_civicrm_config();
-  if ($upgrader = _rc_base_civix_upgrader()) {
-    $upgrader->onUninstall();
-  }
+function _rc_base_civix_civicrm_uninstall()
+{
+    _rc_base_civix_civicrm_config();
+    if ($upgrader = _rc_base_civix_upgrader()) {
+        $upgrader->onUninstall();
+    }
 }
 
 /**
@@ -163,13 +171,14 @@ function _rc_base_civix_civicrm_uninstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
-function _rc_base_civix_civicrm_enable() {
-  _rc_base_civix_civicrm_config();
-  if ($upgrader = _rc_base_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onEnable'])) {
-      $upgrader->onEnable();
+function _rc_base_civix_civicrm_enable()
+{
+    _rc_base_civix_civicrm_config();
+    if ($upgrader = _rc_base_civix_upgrader()) {
+        if (is_callable([$upgrader, 'onEnable'])) {
+            $upgrader->onEnable();
+        }
     }
-  }
 }
 
 /**
@@ -178,13 +187,14 @@ function _rc_base_civix_civicrm_enable() {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
  * @return mixed
  */
-function _rc_base_civix_civicrm_disable() {
-  _rc_base_civix_civicrm_config();
-  if ($upgrader = _rc_base_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onDisable'])) {
-      $upgrader->onDisable();
+function _rc_base_civix_civicrm_disable()
+{
+    _rc_base_civix_civicrm_config();
+    if ($upgrader = _rc_base_civix_upgrader()) {
+        if (is_callable([$upgrader, 'onDisable'])) {
+            $upgrader->onDisable();
+        }
     }
-  }
 }
 
 /**
@@ -199,22 +209,23 @@ function _rc_base_civix_civicrm_disable() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
-function _rc_base_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  if ($upgrader = _rc_base_civix_upgrader()) {
-    return $upgrader->onUpgrade($op, $queue);
-  }
+function _rc_base_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = null)
+{
+    if ($upgrader = _rc_base_civix_upgrader()) {
+        return $upgrader->onUpgrade($op, $queue);
+    }
 }
 
 /**
  * @return CRM_RcBase_Upgrader
  */
-function _rc_base_civix_upgrader() {
-  if (!file_exists(__DIR__ . '/CRM/RcBase/Upgrader.php')) {
-    return NULL;
-  }
-  else {
-    return CRM_RcBase_Upgrader_Base::instance();
-  }
+function _rc_base_civix_upgrader()
+{
+    if (!file_exists(__DIR__ . '/CRM/RcBase/Upgrader.php')) {
+        return null;
+    } else {
+        return CRM_RcBase_Upgrader_Base::instance();
+    }
 }
 
 /**
@@ -228,33 +239,33 @@ function _rc_base_civix_upgrader() {
  *
  * @return array
  */
-function _rc_base_civix_find_files($dir, $pattern) {
-  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
+function _rc_base_civix_find_files($dir, $pattern)
+{
+    if (is_callable(['CRM_Utils_File', 'findFiles'])) {
+        return CRM_Utils_File::findFiles($dir, $pattern);
+    }
 
-  $todos = [$dir];
-  $result = [];
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_rc_base_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry[0] == '.') {
+    $todos = [$dir];
+    $result = [];
+    while (!empty($todos)) {
+        $subdir = array_shift($todos);
+        foreach (_rc_base_civix_glob("$subdir/$pattern") as $match) {
+            if (!is_dir($match)) {
+                $result[] = $match;
+            }
         }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
+        if ($dh = opendir($subdir)) {
+            while (false !== ($entry = readdir($dh))) {
+                $path = $subdir . DIRECTORY_SEPARATOR . $entry;
+                if ($entry[0] == '.') {
+                } elseif (is_dir($path)) {
+                    $todos[] = $path;
+                }
+            }
+            closedir($dh);
         }
-      }
-      closedir($dh);
     }
-  }
-  return $result;
+    return $result;
 }
 
 /**
@@ -264,21 +275,22 @@ function _rc_base_civix_find_files($dir, $pattern) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
  */
-function _rc_base_civix_civicrm_managed(&$entities) {
-  $mgdFiles = _rc_base_civix_find_files(__DIR__, '*.mgd.php');
-  sort($mgdFiles);
-  foreach ($mgdFiles as $file) {
-    $es = include $file;
-    foreach ($es as $e) {
-      if (empty($e['module'])) {
-        $e['module'] = E::LONG_NAME;
-      }
-      if (empty($e['params']['version'])) {
-        $e['params']['version'] = '3';
-      }
-      $entities[] = $e;
+function _rc_base_civix_civicrm_managed(&$entities)
+{
+    $mgdFiles = _rc_base_civix_find_files(__DIR__, '*.mgd.php');
+    sort($mgdFiles);
+    foreach ($mgdFiles as $file) {
+        $es = include $file;
+        foreach ($es as $e) {
+            if (empty($e['module'])) {
+                $e['module'] = E::LONG_NAME;
+            }
+            if (empty($e['params']['version'])) {
+                $e['params']['version'] = '3';
+            }
+            $entities[] = $e;
+        }
     }
-  }
 }
 
 /**
@@ -290,23 +302,24 @@ function _rc_base_civix_civicrm_managed(&$entities) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
-function _rc_base_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
-    return;
-  }
-
-  foreach (_rc_base_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
-    $name = preg_replace('/\.xml$/', '', basename($file));
-    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
-      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      throw new CRM_Core_Exception($errorMessage);
+function _rc_base_civix_civicrm_caseTypes(&$caseTypes)
+{
+    if (!is_dir(__DIR__ . '/xml/case')) {
+        return;
     }
-    $caseTypes[$name] = [
+
+    foreach (_rc_base_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
+        $name = preg_replace('/\.xml$/', '', basename($file));
+        if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
+            $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
+            throw new CRM_Core_Exception($errorMessage);
+        }
+        $caseTypes[$name] = [
       'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
     ];
-  }
+    }
 }
 
 /**
@@ -318,20 +331,21 @@ function _rc_base_civix_civicrm_caseTypes(&$caseTypes) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
-function _rc_base_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
-    return;
-  }
-
-  $files = _rc_base_civix_glob(__DIR__ . '/ang/*.ang.php');
-  foreach ($files as $file) {
-    $name = preg_replace(':\.ang\.php$:', '', basename($file));
-    $module = include $file;
-    if (empty($module['ext'])) {
-      $module['ext'] = E::LONG_NAME;
+function _rc_base_civix_civicrm_angularModules(&$angularModules)
+{
+    if (!is_dir(__DIR__ . '/ang')) {
+        return;
     }
-    $angularModules[$name] = $module;
-  }
+
+    $files = _rc_base_civix_glob(__DIR__ . '/ang/*.ang.php');
+    foreach ($files as $file) {
+        $name = preg_replace(':\.ang\.php$:', '', basename($file));
+        $module = include $file;
+        if (empty($module['ext'])) {
+            $module['ext'] = E::LONG_NAME;
+        }
+        $angularModules[$name] = $module;
+    }
 }
 
 /**
@@ -339,18 +353,19 @@ function _rc_base_civix_civicrm_angularModules(&$angularModules) {
  *
  * Find any and return any files matching "*.theme.php"
  */
-function _rc_base_civix_civicrm_themes(&$themes) {
-  $files = _rc_base_civix_glob(__DIR__ . '/*.theme.php');
-  foreach ($files as $file) {
-    $themeMeta = include $file;
-    if (empty($themeMeta['name'])) {
-      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+function _rc_base_civix_civicrm_themes(&$themes)
+{
+    $files = _rc_base_civix_glob(__DIR__ . '/*.theme.php');
+    foreach ($files as $file) {
+        $themeMeta = include $file;
+        if (empty($themeMeta['name'])) {
+            $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+        }
+        if (empty($themeMeta['ext'])) {
+            $themeMeta['ext'] = E::LONG_NAME;
+        }
+        $themes[$themeMeta['name']] = $themeMeta;
     }
-    if (empty($themeMeta['ext'])) {
-      $themeMeta['ext'] = E::LONG_NAME;
-    }
-    $themes[$themeMeta['name']] = $themeMeta;
-  }
 }
 
 /**
@@ -366,9 +381,10 @@ function _rc_base_civix_civicrm_themes(&$themes) {
  *
  * @return array
  */
-function _rc_base_civix_glob($pattern) {
-  $result = glob($pattern);
-  return is_array($result) ? $result : [];
+function _rc_base_civix_glob($pattern)
+{
+    $result = glob($pattern);
+    return is_array($result) ? $result : [];
 }
 
 /**
@@ -382,75 +398,78 @@ function _rc_base_civix_glob($pattern) {
  *
  * @return bool
  */
-function _rc_base_civix_insert_navigation_menu(&$menu, $path, $item) {
-  // If we are done going down the path, insert menu
-  if (empty($path)) {
-    $menu[] = [
+function _rc_base_civix_insert_navigation_menu(&$menu, $path, $item)
+{
+    // If we are done going down the path, insert menu
+    if (empty($path)) {
+        $menu[] = [
       'attributes' => array_merge([
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
       ], $item),
     ];
-    return TRUE;
-  }
-  else {
-    // Find an recurse into the next level down
-    $found = FALSE;
-    $path = explode('/', $path);
-    $first = array_shift($path);
-    foreach ($menu as $key => &$entry) {
-      if ($entry['attributes']['name'] == $first) {
-        if (!isset($entry['child'])) {
-          $entry['child'] = [];
+        return true;
+    } else {
+        // Find an recurse into the next level down
+        $found = false;
+        $path = explode('/', $path);
+        $first = array_shift($path);
+        foreach ($menu as $key => &$entry) {
+            if ($entry['attributes']['name'] == $first) {
+                if (!isset($entry['child'])) {
+                    $entry['child'] = [];
+                }
+                $found = _rc_base_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+            }
         }
-        $found = _rc_base_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
-      }
+        return $found;
     }
-    return $found;
-  }
 }
 
 /**
  * (Delegated) Implements hook_civicrm_navigationMenu().
  */
-function _rc_base_civix_navigationMenu(&$nodes) {
-  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
-    _rc_base_civix_fixNavigationMenu($nodes);
-  }
+function _rc_base_civix_navigationMenu(&$nodes)
+{
+    if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+        _rc_base_civix_fixNavigationMenu($nodes);
+    }
 }
 
 /**
  * Given a navigation menu, generate navIDs for any items which are
  * missing them.
  */
-function _rc_base_civix_fixNavigationMenu(&$nodes) {
-  $maxNavID = 1;
-  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
-    if ($key === 'navID') {
-      $maxNavID = max($maxNavID, $item);
-    }
-  });
-  _rc_base_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+function _rc_base_civix_fixNavigationMenu(&$nodes)
+{
+    $maxNavID = 1;
+    array_walk_recursive($nodes, function ($item, $key) use (&$maxNavID) {
+        if ($key === 'navID') {
+            $maxNavID = max($maxNavID, $item);
+        }
+    });
+    _rc_base_civix_fixNavigationMenuItems($nodes, $maxNavID, null);
 }
 
-function _rc_base_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
-  $origKeys = array_keys($nodes);
-  foreach ($origKeys as $origKey) {
-    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
-      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+function _rc_base_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID)
+{
+    $origKeys = array_keys($nodes);
+    foreach ($origKeys as $origKey) {
+        if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== null) {
+            $nodes[$origKey]['attributes']['parentID'] = $parentID;
+        }
+        // If no navID, then assign navID and fix key.
+        if (!isset($nodes[$origKey]['attributes']['navID'])) {
+            $newKey = ++$maxNavID;
+            $nodes[$origKey]['attributes']['navID'] = $newKey;
+            $nodes[$newKey] = $nodes[$origKey];
+            unset($nodes[$origKey]);
+            $origKey = $newKey;
+        }
+        if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+            _rc_base_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+        }
     }
-    // If no navID, then assign navID and fix key.
-    if (!isset($nodes[$origKey]['attributes']['navID'])) {
-      $newKey = ++$maxNavID;
-      $nodes[$origKey]['attributes']['navID'] = $newKey;
-      $nodes[$newKey] = $nodes[$origKey];
-      unset($nodes[$origKey]);
-      $origKey = $newKey;
-    }
-    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
-      _rc_base_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
-    }
-  }
 }
 
 /**
@@ -458,11 +477,12 @@ function _rc_base_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
  */
-function _rc_base_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
+function _rc_base_civix_civicrm_alterSettingsFolders(&$metaDataFolders = null)
+{
+    $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
+    if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+        $metaDataFolders[] = $settingsDir;
+    }
 }
 
 /**
@@ -472,6 +492,7 @@ function _rc_base_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
-function _rc_base_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, []);
+function _rc_base_civix_civicrm_entityTypes(&$entityTypes)
+{
+    $entityTypes = array_merge($entityTypes, []);
 }

--- a/tests/phpunit/CRM/RcBase/Api/CreateHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/CreateHeadlessTest.php
@@ -32,7 +32,7 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $data = $this->cvApi4Get(
             'Contact',
             ['contact_type', 'first_name', 'middle_name', 'last_name', 'external_identifier'],
-            ["id=".$id[0]['id']]
+            ['id='.$id[0]['id']]
         );
         $this->assertCount(1, $data, 'Not one result returned for "data"');
 
@@ -56,8 +56,8 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         CRM_RcBase_Api_Create::contact($contact);
 
         // Create same contact
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("DB Error: already exists", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('DB Error: already exists', 'Invalid exception message.');
         CRM_RcBase_Api_Create::contact($contact);
     }
 
@@ -83,7 +83,7 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $data = $this->cvApi4Get(
             'Contact',
             ['contact_type', 'first_name', 'middle_name', 'last_name', 'external_identifier'],
-            ["id=".$id[0]['id']]
+            ['id='.$id[0]['id']]
         );
         $this->assertCount(1, $data, 'Not one result returned for "data"');
 
@@ -124,7 +124,7 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $data = $this->cvApi4Get(
             'Email',
             ['email', 'location_type_id'],
-            ["id=".$id[0]['id']]
+            ['id='.$id[0]['id']]
         );
         $this->assertCount(1, $data, 'Not one result returned for "data"');
 
@@ -136,8 +136,8 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $this->assertSame($data[0], $email, 'Bad email data returned');
 
         // Check invalid ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Create::email(0, $email);
     }
 
@@ -153,8 +153,8 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $email = [
             'location_type_id' => 2,
         ];
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Mandatory values missing", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Mandatory values missing', 'Invalid exception message.');
         CRM_RcBase_Api_Create::email($contact_id, $email);
     }
 
@@ -171,8 +171,8 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
             'email' => 'ovidius@senate.rome',
             'location_type_id' => 2,
         ];
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("DB Error: constraint violation", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('DB Error: constraint violation', 'Invalid exception message.');
         CRM_RcBase_Api_Create::email($contact_id, $email);
     }
 
@@ -205,7 +205,7 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $data = $this->cvApi4Get(
             'Phone',
             ['phone', 'location_type_id'],
-            ["id=".$id[0]['id']]
+            ['id='.$id[0]['id']]
         );
         $this->assertCount(1, $data, 'Not one result returned for "data"');
 
@@ -217,8 +217,8 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $this->assertSame($data[0], $phone, 'Bad phone data returned');
 
         // Check invalid ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Create::phone(-4, $phone);
     }
 
@@ -251,7 +251,7 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $data = $this->cvApi4Get(
             'Address',
             ['city', 'location_type_id'],
-            ["id=".$id[0]['id']]
+            ['id='.$id[0]['id']]
         );
         $this->assertCount(1, $data, 'Not one result returned for "data"');
 
@@ -263,8 +263,8 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $this->assertSame($data[0], $address, 'Bad address data returned');
 
         // Check invalid ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Create::address(0, $address);
     }
 
@@ -304,7 +304,7 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $data = $this->cvApi4Get(
             'Relationship',
             ['contact_id_b', 'relationship_type_id', 'description'],
-            ["id=".$id[0]['id']]
+            ['id='.$id[0]['id']]
         );
         $this->assertCount(1, $data, 'Not one result returned for "data"');
 
@@ -316,8 +316,8 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $this->assertSame($data[0], $relationship, 'Bad relationship data returned');
 
         // Check invalid ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Create::relationship(0, $relationship);
     }
 
@@ -355,7 +355,7 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $data = $this->cvApi4Get(
             'Contribution',
             ['financial_type_id', 'total_amount', 'trxn_id'],
-            ["id=".$id[0]['id']]
+            ['id='.$id[0]['id']]
         );
         $this->assertCount(1, $data, 'Not one result returned for "data"');
 
@@ -367,8 +367,8 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $this->assertSame($data[0], $contribution, 'Bad contribution data returned');
 
         // Check invalid ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Create::contribution(-20, $contribution);
     }
 
@@ -389,8 +389,8 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         CRM_RcBase_Api_Create::contribution($contact_id, $contribution);
 
         // Create same contribution
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Duplicate error", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Duplicate error', 'Invalid exception message.');
         CRM_RcBase_Api_Create::contribution($contact_id, $contribution);
     }
 
@@ -426,7 +426,7 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $data = $this->cvApi4Get(
             'Activity',
             ['activity_type_id', 'subject'],
-            ["id=".$id[0]['id']]
+            ['id='.$id[0]['id']]
         );
         $this->assertCount(1, $data, 'Not one result returned for "data"');
 
@@ -439,8 +439,8 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $this->assertSame($data[0], $activity, 'Bad activity data returned');
 
         // Check invalid ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Create::activity(-5, $activity);
     }
 
@@ -484,8 +484,8 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $this->assertSame($id[0]['id'], $entity_tag_id, 'Bad entity tag ID returned');
 
         // Check invalid ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Create::tagContact(-20, $tag_id);
     }
 
@@ -501,8 +501,8 @@ class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $tag_id = $this->getNextAutoIncrementValue('civicrm_tag');
 
         // Check non-existent tag ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("DB Error: constraint violation", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('DB Error: constraint violation', 'Invalid exception message.');
         CRM_RcBase_Api_Create::tagContact($contact_id, $tag_id);
     }
 }

--- a/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/GetHeadlessTest.php
@@ -58,11 +58,11 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
         );
 
         // Check empty email
-        $this->assertNull(CRM_RcBase_Api_Get::contactIDFromEmail(""), 'Not null returned on empty email');
+        $this->assertNull(CRM_RcBase_Api_Get::contactIDFromEmail(''), 'Not null returned on empty email');
 
         // Check non-existent email
         $this->assertNull(
-            CRM_RcBase_Api_Get::contactIDFromEmail("nonexistent@rome.com"),
+            CRM_RcBase_Api_Get::contactIDFromEmail('nonexistent@rome.com'),
             'Not null returned on non-existent email'
         );
     }
@@ -99,11 +99,11 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
         );
 
         // Check empty id
-        $this->assertNull(CRM_RcBase_Api_Get::contactIDFromExternalID(""), 'Not null returned on empty email');
+        $this->assertNull(CRM_RcBase_Api_Get::contactIDFromExternalID(''), 'Not null returned on empty email');
 
         // Check non-existent id
         $this->assertNull(
-            CRM_RcBase_Api_Get::contactIDFromExternalID("11-nonexistent"),
+            CRM_RcBase_Api_Get::contactIDFromExternalID('11-nonexistent'),
             'Not null returned on non-existent email'
         );
     }
@@ -154,8 +154,8 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
         );
 
         // Check invalid ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Get::contactData(0);
     }
 
@@ -166,8 +166,8 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
      */
     public function testGetContactDataWithInvalidId()
     {
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Get::contactData(-5);
     }
 
@@ -211,8 +211,8 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
         );
 
         // Check invalid ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Get::emailID(-1, $email['location_type_id']);
     }
 
@@ -256,8 +256,8 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
         );
 
         // Check invalid ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Get::phoneID(-5, $phone['location_type_id']);
     }
 
@@ -301,8 +301,8 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
         );
 
         // Check invalid ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Get::addressID($contact_id, 0);
     }
 
@@ -352,8 +352,8 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
         );
 
         // Check invalid ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Get::relationshipID($contact_id, $contact_id_other, -5);
     }
 
@@ -458,8 +458,8 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
         $this->assertCount(1, $activities, 'Bad number of activities when contact is the assignee');
 
         // Check invalid ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Get::allActivity($contact_id_target, 5, -5);
     }
 
@@ -509,8 +509,8 @@ class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTestCas
         );
 
         // Check invalid ID
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Get::contactHasTag(-1, $tag_id);
     }
 }

--- a/tests/phpunit/CRM/RcBase/Api/UpdateHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/UpdateHeadlessTest.php
@@ -72,8 +72,8 @@ class CRM_RcBase_Api_UpdateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $contact = [
             'contact_type' => 'Individual',
         ];
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("Invalid ID", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('Invalid ID', 'Invalid exception message.');
         CRM_RcBase_Api_Update::entity('Contact', -5, $contact);
     }
 
@@ -88,8 +88,8 @@ class CRM_RcBase_Api_UpdateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
         $contact = [
             'contact_type' => 'Invalid contact type',
         ];
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("DB Error: syntax error", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('DB Error: syntax error', 'Invalid exception message.');
         CRM_RcBase_Api_Update::contact($contact_id, $contact);
     }
 
@@ -116,8 +116,8 @@ class CRM_RcBase_Api_UpdateHeadlessTest extends CRM_RcBase_Test_BaseHeadlessTest
 
         // Update new contact
         $contact_new = ['external_identifier' => $contact_previous['external_identifier'],];
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class");
-        $this->expectExceptionMessage("DB Error: already exists", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class');
+        $this->expectExceptionMessage('DB Error: already exists', 'Invalid exception message.');
         CRM_RcBase_Api_Update::contact($contact_id_new, $contact_new);
     }
 

--- a/tests/phpunit/CRM/RcBase/ConfigHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/ConfigHeadlessTest.php
@@ -15,22 +15,24 @@ const DEFAULT_CONFIGURATION = [
 ];
 const CONFIG_NAME = "rcBase_test";
 
-class TestConfig extends CRM_RcBase_Config {
-    public function defaultConfiguration(): array {
+class TestConfig extends CRM_RcBase_Config
+{
+    public function defaultConfiguration(): array
+    {
         return DEFAULT_CONFIGURATION;
     }
 }
 /**
  * Config class test cases.
- * It tests the testConfig class that extends from the config and implements the 
+ * It tests the testConfig class that extends from the config and implements the
  * defaultConfiguration method.
  *
  * @group headless
  */
-class CRM_RcBase_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface {
-
-
-    public function setUpHeadless() {
+class CRM_RcBase_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface
+{
+    public function setUpHeadless()
+    {
         return Test::headless()
             ->installMe(__DIR__)
             ->apply();
@@ -40,7 +42,8 @@ class CRM_RcBase_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implemen
      *
      * @throws CRM_Extension_Exception_ParseException
      */
-    public static function setUpBeforeClass(): void {
+    public static function setUpBeforeClass(): void
+    {
         Test::headless()
             ->installMe(__DIR__)
             ->apply(true);
@@ -50,36 +53,42 @@ class CRM_RcBase_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implemen
      *
      * @throws CRM_Extension_Exception_ParseException
      */
-    public static function tearDownAfterClass(): void {
+    public static function tearDownAfterClass(): void
+    {
         Test::headless()
             ->uninstallMe(__DIR__)
             ->apply(true);
     }
 
-    public function setUp(): void {
+    public function setUp(): void
+    {
         parent::setUp();
     }
 
-    public function tearDown(): void {
+    public function tearDown(): void
+    {
         $this->getConfig()->remove();
         parent::tearDown();
     }
 
-    private function getConfig() {
+    private function getConfig()
+    {
         return new TestConfig(CONFIG_NAME);
     }
 
     /**
      * It checks that the create function works well.
      */
-    public function testCreate() {
+    public function testCreate()
+    {
         $config = $this->getConfig();
         self::assertTrue($config->create(), "Create config has to be successful.");
         $cfg = $config->get();
         self::assertSame(DEFAULT_CONFIGURATION, $cfg, "Invalid configuration has been returned.");
         self::assertTrue($config->create(), "Create config has to be successful multiple times.");
     }
-    public function testCreateAfterChanges() {
+    public function testCreateAfterChanges()
+    {
         $config = $this->getConfig();
         self::assertTrue($config->create(), "Create config has to be successful.");
         $cfg = $config->get();
@@ -108,7 +117,8 @@ class CRM_RcBase_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implemen
     /**
      * It checks that the remove function works well.
      */
-    public function testRemove() {
+    public function testRemove()
+    {
         $config = $this->getConfig();
         // preset the config.
         Civi::settings()->add([CONFIG_NAME => DEFAULT_CONFIGURATION]);
@@ -118,7 +128,8 @@ class CRM_RcBase_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implemen
     /**
      * It checks that the get function works well.
      */
-    public function testGet() {
+    public function testGet()
+    {
         $config = $this->getConfig();
         // preset the config.
         Civi::settings()->add([CONFIG_NAME =>DEFAULT_CONFIGURATION]);
@@ -134,7 +145,8 @@ class CRM_RcBase_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implemen
     /**
      * It checks that the update function works well.
      */
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $config = $this->getConfig();
         // preset the config.
         Civi::settings()->add([CONFIG_NAME => DEFAULT_CONFIGURATION]);
@@ -154,13 +166,15 @@ class CRM_RcBase_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implemen
     /**
      * It checks that the get function works well.
      */
-    public function testLoadEmptyConfig() {
+    public function testLoadEmptyConfig()
+    {
         $config = $this->getConfig();
         self::expectException(CRM_Core_Exception::class, "Invalid exception class.");
         self::expectExceptionMessage(CONFIG_NAME."_config config invalid.", "Invalid exception message.");
         self::assertEmpty($config->load(), "Load result supposed to be empty.");
     }
-    public function testLoadCreatedConfig() {
+    public function testLoadCreatedConfig()
+    {
         $config = $this->getConfig();
         // preset the config.
         $config->create();

--- a/tests/phpunit/CRM/RcBase/Processor/BaseTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/BaseTest.php
@@ -20,19 +20,19 @@ class CRM_RcBase_Processor_BaseTest extends TestCase
     {
         // not set.
         $result = CRM_RcBase_Processor_Base::detectContentType();
-        $this->assertEquals("CRM_RcBase_Processor_UrlEncodedForm", $result, "Invalid class returned.");
+        $this->assertEquals('CRM_RcBase_Processor_UrlEncodedForm', $result, 'Invalid class returned.');
         $testData = [
-            "application/json"       => "CRM_RcBase_Processor_JSON",
-            "application/javascript" => "CRM_RcBase_Processor_JSON",
-            "text/xml"               => "CRM_RcBase_Processor_XML",
-            "application/xml"        => "CRM_RcBase_Processor_XML",
-            "text/html"              => "CRM_RcBase_Processor_UrlEncodedForm",
-            "something/other/string" => "CRM_RcBase_Processor_UrlEncodedForm",
+            'application/json' => 'CRM_RcBase_Processor_JSON',
+            'application/javascript' => 'CRM_RcBase_Processor_JSON',
+            'text/xml' => 'CRM_RcBase_Processor_XML',
+            'application/xml' => 'CRM_RcBase_Processor_XML',
+            'text/html' => 'CRM_RcBase_Processor_UrlEncodedForm',
+            'something/other/string' => 'CRM_RcBase_Processor_UrlEncodedForm',
         ];
         foreach ($testData as $k => $v) {
-            $_SERVER["CONTENT_TYPE"] = $k;
+            $_SERVER['CONTENT_TYPE'] = $k;
             $result = CRM_RcBase_Processor_Base::detectContentType();
-            $this->assertEquals($v, $result, "Invalid class returned.");
+            $this->assertEquals($v, $result, 'Invalid class returned.');
         }
     }
 
@@ -44,19 +44,19 @@ class CRM_RcBase_Processor_BaseTest extends TestCase
     public function provideStringsToSanitize()
     {
         return [
-            'Empty string'         => ["", ""],
-            'No change'            => ["this_is_kept_as_it_is", "this_is_kept_as_it_is"],
-            'Trailing newline'     => ["first word\n", "first word"],
-            'Middle newline'       => ["first\nword", "first\nword"],
-            'Trailing whitespace'  => ["first word  \t\n", "first word"],
-            'Leading whitespace'   => ["\n  \tfirst word", "first word"],
-            'Double whitespace'    => ["first   word\tand\t\tsecond word", "first word\tand second word"],
-            'Double quotes around' => ["\"first_and_last_removed\"", "first_and_last_removed"],
-            'Single quotes around' => ["'first_and_last_also_removed'", "first_and_last_also_removed"],
-            'Quotes inside'        => ["'middle_\"one'_is_kept'", "middle_\"one'_is_kept"],
-            'Tags'                 => [
+            'Empty string' => ['', ''],
+            'No change' => ['this_is_kept_as_it_is', 'this_is_kept_as_it_is'],
+            'Trailing newline' => ["first word\n", 'first word'],
+            'Middle newline' => ["first\nword", "first\nword"],
+            'Trailing whitespace' => ["first word  \t\n", 'first word'],
+            'Leading whitespace' => ["\n  \tfirst word", 'first word'],
+            'Double whitespace' => ["first   word\tand\t\tsecond word", "first word\tand second word"],
+            'Double quotes around' => ["\"first_and_last_removed\"", 'first_and_last_removed'],
+            'Single quotes around' => ["'first_and_last_also_removed'", 'first_and_last_also_removed'],
+            'Quotes inside' => ["'middle_\"one'_is_kept'", "middle_\"one'_is_kept"],
+            'Tags' => [
                 "without_html_<a href=\"site.com\" target=\"_blank\">link</a>_tags",
-                "without_html_link_tags",
+                'without_html_link_tags',
             ],
         ];
     }
@@ -70,7 +70,7 @@ class CRM_RcBase_Processor_BaseTest extends TestCase
     public function testSanitizeString($input, $expected)
     {
         $result = CRM_RcBase_Processor_Base::sanitizeString($input);
-        $this->assertEquals($expected, $result, "Invalid sanitized string returned.");
+        $this->assertEquals($expected, $result, 'Invalid sanitized string returned.');
     }
 
     /**
@@ -79,18 +79,18 @@ class CRM_RcBase_Processor_BaseTest extends TestCase
     public function provideBasicTypeToSanitize()
     {
         return [
-            'string'           => ["\n  \t'first'<alert> word'  ", "first' word"],
+            'string' => ["\n  \t'first'<alert> word'  ", "first' word"],
             'positive integer' => [3, 3],
-            'zero integer'     => [0, 0],
+            'zero integer' => [0, 0],
             'negative integer' => [-1, -1],
-            'positive float'   => [3.3, 3.3],
-            'zero float'       => [0.0, 0.0],
-            'negative float'   => [-1.9, -1.9],
-            'bool true'        => [true, true],
-            'bool false'       => [false, false],
-            'null'             => [null, null],
-            'empty array'      => [[], null],
-            'empty string'     => ["", ""],
+            'positive float' => [3.3, 3.3],
+            'zero float' => [0.0, 0.0],
+            'negative float' => [-1.9, -1.9],
+            'bool true' => [true, true],
+            'bool false' => [false, false],
+            'null' => [null, null],
+            'empty array' => [[], null],
+            'empty string' => ['', ''],
         ];
     }
 
@@ -103,7 +103,7 @@ class CRM_RcBase_Processor_BaseTest extends TestCase
     public function testSanitizeWithBasicInputTypes($input, $expected)
     {
         $result = CRM_RcBase_Processor_Base::sanitize($input);
-        $this->assertEquals($expected, $result, "Invalid sanitized value returned.");
+        $this->assertEquals($expected, $result, 'Invalid sanitized value returned.');
     }
 
     /**
@@ -112,10 +112,10 @@ class CRM_RcBase_Processor_BaseTest extends TestCase
     public function testSanitizeWithComplexArray()
     {
         $input = [
-            "  <script>alert(hack)\t</script>\n" => "this is a test",
-            'sub_array'                          => [
-                "first ",
-                "se   cond",
+            "  <script>alert(hack)\t</script>\n" => 'this is a test',
+            'sub_array' => [
+                'first ',
+                'se   cond',
                 15,
                 true,
                 null,
@@ -123,339 +123,339 @@ class CRM_RcBase_Processor_BaseTest extends TestCase
                 [1, 2, 3],
                 [
                     're   curse <html>' => '"index" ',
-                    'integer'           => 5,
-                    'boolean'           => true,
-                    're-recurse'        => [
+                    'integer' => 5,
+                    'boolean' => true,
+                    're-recurse' => [
                         'greater_than' => '>15',
-                        'less then'    => '>11',
-                        'tags'         => '<input/>testing<br/>',
-                        5              => null,
-                        6              => ' six',
+                        'less then' => '>11',
+                        'tags' => '<input/>testing<br/>',
+                        5 => null,
+                        6 => ' six',
                     ],
                 ],
             ],
-            'email '                             => "test@example.com\n",
-            'UTF-8'                              => 'kéményŐÜÖÓúőü$!#~`\\|',
+            'email ' => "test@example.com\n",
+            'UTF-8' => 'kéményŐÜÖÓúőü$!#~`\\|',
         ];
         $expected = [
-            "alert(hack)\t" => "this is a test",
-            'sub_array'     => [
-                "first",
-                "se cond",
+            "alert(hack)\t" => 'this is a test',
+            'sub_array' => [
+                'first',
+                'se cond',
                 15,
                 true,
                 null,
                 -45.431,
                 [1, 2, 3],
                 [
-                    're curse '  => 'index',
-                    'integer'    => 5,
-                    'boolean'    => true,
+                    're curse ' => 'index',
+                    'integer' => 5,
+                    'boolean' => true,
                     're-recurse' => [
                         'greater_than' => '>15',
-                        'less then'    => '>11',
-                        'tags'         => 'testing',
-                        5              => null,
-                        6              => 'six',
+                        'less then' => '>11',
+                        'tags' => 'testing',
+                        5 => null,
+                        6 => 'six',
                     ],
                 ],
             ],
-            'email'         => "test@example.com",
-            'UTF-8'         => 'kéményŐÜÖÓúőü$!#~`\\|',
+            'email' => 'test@example.com',
+            'UTF-8' => 'kéményŐÜÖÓúőü$!#~`\\|',
         ];
         $result = CRM_RcBase_Processor_Base::sanitize($input);
-        $this->assertEquals($expected, $result, "Invalid sanitized array returned.");
+        $this->assertEquals($expected, $result, 'Invalid sanitized array returned.');
     }
 
     public function testValidateInputMissingTypeThrowsException()
     {
-        $value = "testvalue";
-        $type = "";
-        $name = "testname";
+        $value = 'testvalue';
+        $type = '';
+        $name = 'testname';
         $required = false;
         $allowedValues = [];
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("Variable type missing", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage('Variable type missing', 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name, $required, $allowedValues);
     }
 
     public function testValidateInputMissingNameThrowsException()
     {
-        $value = "testvalue";
-        $type = "testtype";
-        $name = "";
+        $value = 'testvalue';
+        $type = 'testtype';
+        $name = '';
         $required = false;
         $allowedValues = [];
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("Variable name missing", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage('Variable name missing', 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name, $required, $allowedValues);
     }
 
     public function testValidateInputEmptyRequiredValueThrowsException()
     {
-        $value = "";
-        $type = "testtype";
-        $name = "testname";
+        $value = '';
+        $type = 'testtype';
+        $name = 'testname';
         $required = true;
         $allowedValues = [];
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("Missing parameter: ".$name, "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage('Missing parameter: '.$name, 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name, $required, $allowedValues);
     }
 
     public function testValidateInputNotSupportedTypeThrowsException()
     {
-        $value = "testvalue";
-        $type = "invalidTypeName";
-        $name = "testname";
+        $value = 'testvalue';
+        $type = 'invalidTypeName';
+        $name = 'testname';
         $required = false;
         $allowedValues = [];
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("Not supported type: ".$type, "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage('Not supported type: '.$type, 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name, $required, $allowedValues);
     }
 
     public function testValidateInputNotAllowedValueThrowsException()
     {
-        $value = "invalid value";
-        $type = "string";
-        $name = "testname";
+        $value = 'invalid value';
+        $type = 'string';
+        $name = 'testname';
         $required = false;
-        $allowedValues = ["ON", "OFF"];
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("Not allowed value for: ".$name." (".$value.")", "Invalid exception message.");
+        $allowedValues = ['ON', 'OFF'];
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage('Not allowed value for: '.$name.' ('.$value.')', 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name, $required, $allowedValues);
     }
 
     public function testValidateStringWithArrayThrowsException()
     {
         $value = ['test'];
-        $type = "string";
-        $name = "array instead string";
+        $type = 'string';
+        $name = 'array instead string';
 
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("${name} is not type of: ${type}", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage("${name} is not type of: ${type}", 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name);
     }
 
     public function testValidateEmailWithMissingLocalPartThrowsException()
     {
         $value = '@example.com';
-        $type = "email";
-        $name = "missing local part";
+        $type = 'email';
+        $name = 'missing local part';
 
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("${name} is not type of: ${type}", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage("${name} is not type of: ${type}", 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name);
     }
 
     public function testValidateEmailWithMissingDomainThrowsException()
     {
         $value = 'test@';
-        $type = "email";
-        $name = "missing domain";
+        $type = 'email';
+        $name = 'missing domain';
 
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("${name} is not type of: ${type}", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage("${name} is not type of: ${type}", 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name);
     }
 
     public function testValidateEmailWithMissingTopLevelDomainThrowsException()
     {
         $value = 'test@example';
-        $type = "email";
-        $name = "missing top level domain";
+        $type = 'email';
+        $name = 'missing top level domain';
 
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("${name} is not type of: ${type}", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage("${name} is not type of: ${type}", 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name);
     }
 
     public function testValidateIntegerWithStringThrowsException()
     {
         $value = 'string';
-        $type = "int";
-        $name = "string";
+        $type = 'int';
+        $name = 'string';
 
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("${name} is not type of: ${type}", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage("${name} is not type of: ${type}", 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name);
     }
 
     public function testValidateFloatWithStringThrowsException()
     {
         $value = 'string';
-        $type = "float";
-        $name = "string";
+        $type = 'float';
+        $name = 'string';
 
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("${name} is not type of: ${type}", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage("${name} is not type of: ${type}", 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name);
     }
 
     public function testValidateBoolWithStringThrowsException()
     {
         $value = 'string';
-        $type = "bool";
-        $name = "string";
+        $type = 'bool';
+        $name = 'string';
 
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("${name} is not type of: ${type}", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage("${name} is not type of: ${type}", 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name);
     }
 
     public function testValidateDateWithTimeThrowsException()
     {
         $value = '202004021531';
-        $type = "date";
-        $name = "date with time";
+        $type = 'date';
+        $name = 'date with time';
 
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("${name} is not type of: ${type}", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage("${name} is not type of: ${type}", 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name);
     }
 
     public function testValidateDateTimeWithMissingDayThrowsException()
     {
         $value = '202011';
-        $type = "datetime";
-        $name = "missing day";
+        $type = 'datetime';
+        $name = 'missing day';
 
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("${name} is not type of: ${type}", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage("${name} is not type of: ${type}", 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name);
     }
 
     public function testValidateDateTimeWithMissingDayMonthThrowsException()
     {
         $value = '2020';
-        $type = "datetime";
-        $name = "missing day month";
+        $type = 'datetime';
+        $name = 'missing day month';
 
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("${name} is not type of: ${type}", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage("${name} is not type of: ${type}", 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name);
     }
 
     public function testValidateDateTimeWithRandomStringThrowsException()
     {
         $value = 'random';
-        $type = "datetime";
-        $name = "random string";
+        $type = 'datetime';
+        $name = 'random string';
 
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("${name} is not type of: ${type}", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage("${name} is not type of: ${type}", 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name);
     }
 
     public function testValidateDateTimeIsoWithMissingDecimalsThrowsException()
     {
-        $value = "2020-12-01T03:19:46+04:30";
-        $type = "datetimeIso";
-        $name = "missing seconds decimals";
+        $value = '2020-12-01T03:19:46+04:30';
+        $type = 'datetimeIso';
+        $name = 'missing seconds decimals';
 
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("${name} is not type of: ${type}", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage("${name} is not type of: ${type}", 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name);
     }
 
     public function testValidateDateTimeIsoWithTooMuchDecimalsThrowsException()
     {
-        $value = "2020-12-01T03:19:46.1234567+04:30";
-        $type = "datetimeIso";
-        $name = "more than 6 seconds decimals";
+        $value = '2020-12-01T03:19:46.1234567+04:30';
+        $type = 'datetimeIso';
+        $name = 'more than 6 seconds decimals';
 
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("${name} is not type of: ${type}", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage("${name} is not type of: ${type}", 'Invalid exception message.');
         CRM_RcBase_Processor_Base::validateInput($value, $type, $name);
     }
 
     public function provideValidInput()
     {
         return [
-            'empty string'                       => ["", "string", "empty string", false, [],],
-            'no allowed specified'               => ["any string", "string", "no allowed specified", false, [],],
-            'required'                           => ["any string", "string", "required", true, [],],
-            'valid and allowed'                  => [
-                "valid string value 1",
-                "string",
-                "valid and allowed",
+            'empty string' => ['', 'string', 'empty string', false, [],],
+            'no allowed specified' => ['any string', 'string', 'no allowed specified', false, [],],
+            'required' => ['any string', 'string', 'required', true, [],],
+            'valid and allowed' => [
+                'valid string value 1',
+                'string',
+                'valid and allowed',
                 false,
-                ["valid string value 1", "valid string value 2"],
+                ['valid string value 1', 'valid string value 2'],
             ],
-            'valid allowed and required'         => [
-                "valid string value 2",
-                "string",
-                "valid allowed and required",
+            'valid allowed and required' => [
+                'valid string value 2',
+                'string',
+                'valid allowed and required',
                 true,
-                ["valid string value 1", "valid string value 2"],
+                ['valid string value 1', 'valid string value 2'],
             ],
-            'email address'                      => ["email@addr.hu", "email", "email address", false, []],
-            'integer as int'                     => [87, "int", "integer as int", false, [12, "87"]],
-            'integer as string'                  => ["12", "int", "integer as string", false, [12, "87"],],
-            'negative integer as int'            => [-12, "int", "negative integer as int", false, [],],
-            'negative integer as string'         => ["-12", "int", "negative integer as string", false, [],],
-            'ID as int'                          => [12, "id", "ID as int", false, [],],
-            'ID as string'                       => ["12", "id", "ID as string", false, [],],
-            'float as float'                     => [12.1, "float", "float as float", false, [],],
-            'float as string'                    => ["12.1", "float", "float as string", false, [],],
-            'bool as bool'                       => [false, "bool", "bool as bool", false, [],],
-            'bool as truthy int'                 => [1, "bool", "bool as truthy int", false, [],],
-            'bool as falsy int'                  => [0, "bool", "bool as falsy int", false, [],],
-            'bool as truthy string'              => ["Y", "bool", "bool as truthy string", false, [],],
-            'bool as falsy string'               => ["no", "bool", "bool as falsy string", false, [],],
-            'date full'                          => ["2020-08-13", "date", "date full", false, [],],
-            'date compact'                       => ["20200813", "date", "date compact", false, [],],
-            'datetime'                           => ["2020-11-27 04:52:28", "datetime", "datetime full", false, [],],
-            'datetime only date'                 => ["2020-11-27", "datetime", "datetime only date", false, [],],
-            'datetime compact'                   => ["20201127045228", "datetime", "datetime compact", false, [],],
-            'datetime no seconds'                => ["2020-11-27 04:52", "datetime", "datetime no seconds", false, [],],
-            'datetime no seconds compact'        => [
-                "202011270452",
-                "datetime",
-                "datetime no seconds compact",
+            'email address' => ['email@addr.hu', 'email', 'email address', false, []],
+            'integer as int' => [87, 'int', 'integer as int', false, [12, '87']],
+            'integer as string' => ['12', 'int', 'integer as string', false, [12, '87'],],
+            'negative integer as int' => [-12, 'int', 'negative integer as int', false, [],],
+            'negative integer as string' => ['-12', 'int', 'negative integer as string', false, [],],
+            'ID as int' => [12, 'id', 'ID as int', false, [],],
+            'ID as string' => ['12', 'id', 'ID as string', false, [],],
+            'float as float' => [12.1, 'float', 'float as float', false, [],],
+            'float as string' => ['12.1', 'float', 'float as string', false, [],],
+            'bool as bool' => [false, 'bool', 'bool as bool', false, [],],
+            'bool as truthy int' => [1, 'bool', 'bool as truthy int', false, [],],
+            'bool as falsy int' => [0, 'bool', 'bool as falsy int', false, [],],
+            'bool as truthy string' => ['Y', 'bool', 'bool as truthy string', false, [],],
+            'bool as falsy string' => ['no', 'bool', 'bool as falsy string', false, [],],
+            'date full' => ['2020-08-13', 'date', 'date full', false, [],],
+            'date compact' => ['20200813', 'date', 'date compact', false, [],],
+            'datetime' => ['2020-11-27 04:52:28', 'datetime', 'datetime full', false, [],],
+            'datetime only date' => ['2020-11-27', 'datetime', 'datetime only date', false, [],],
+            'datetime compact' => ['20201127045228', 'datetime', 'datetime compact', false, [],],
+            'datetime no seconds' => ['2020-11-27 04:52', 'datetime', 'datetime no seconds', false, [],],
+            'datetime no seconds compact' => [
+                '202011270452',
+                'datetime',
+                'datetime no seconds compact',
                 false,
                 [],
             ],
-            'datetime ISO'                       => [
-                "2020-12-01T03:19:46.101Z",
-                "datetimeIso",
-                "datetime ISO",
+            'datetime ISO' => [
+                '2020-12-01T03:19:46.101Z',
+                'datetimeIso',
+                'datetime ISO',
                 false,
                 [],
             ],
-            'datetime ISO plus timezone'         => [
-                "2020-12-01T03:19:46.101+02:00",
-                "datetimeIso",
-                "datetime ISO plus timezone",
+            'datetime ISO plus timezone' => [
+                '2020-12-01T03:19:46.101+02:00',
+                'datetimeIso',
+                'datetime ISO plus timezone',
                 false,
                 [],
             ],
-            'datetime ISO minus timezone'        => [
-                "2020-12-01T03:19:46.101-05:30",
-                "datetimeIso",
-                "datetime ISO minus timezone",
+            'datetime ISO minus timezone' => [
+                '2020-12-01T03:19:46.101-05:30',
+                'datetimeIso',
+                'datetime ISO minus timezone',
                 false,
                 [],
             ],
             'datetime ISO 1 digits microseconds' => [
-                "2020-12-01T03:19:46.1Z",
-                "datetimeIso",
-                "datetime ISO 2 digits microseconds",
+                '2020-12-01T03:19:46.1Z',
+                'datetimeIso',
+                'datetime ISO 2 digits microseconds',
                 false,
                 [],
             ],
             'datetime ISO 3 digits microseconds' => [
-                "2020-12-01T03:19:46.123Z",
-                "datetimeIso",
-                "datetime ISO 3 digits microseconds",
+                '2020-12-01T03:19:46.123Z',
+                'datetimeIso',
+                'datetime ISO 3 digits microseconds',
                 false,
                 [],
             ],
             'datetime ISO 6 digits microseconds' => [
-                "2020-12-01T03:19:46.123456Z",
-                "datetimeIso",
-                "datetime ISO 6 digits microseconds",
+                '2020-12-01T03:19:46.123456Z',
+                'datetimeIso',
+                'datetime ISO 6 digits microseconds',
                 false,
                 [],
             ],
@@ -476,10 +476,10 @@ class CRM_RcBase_Processor_BaseTest extends TestCase
         try {
             $this->assertEmpty(
                 CRM_RcBase_Processor_Base::validateInput($value, $type, $name, $required, $allowedValues),
-                "Should be empty for valid setup.");
+                'Should be empty for valid setup.'
+            );
         } catch (Exception $ex) {
-            $this->fail("Should not throw exception for valid setup. ".$ex->getMessage());
+            $this->fail('Should not throw exception for valid setup. '.$ex->getMessage());
         }
     }
-
 }

--- a/tests/phpunit/CRM/RcBase/Processor/ConfigTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/ConfigTest.php
@@ -9,24 +9,23 @@ use PHPUnit\Framework\TestCase;
  */
 class CRM_RcBase_Processor_ConfigTest extends TestCase
 {
-
     public function provideStrings()
     {
         return [
-            'null'         => ["option=null", ['option' => null,]],
-            'empty string' => ["option=", ['option' => '',]],
-            'string'       => ["option=string", ['option' => 'string',]],
-            'integer'      => ["integer=42", ['integer' => 42,]],
-            'float'        => ["float=7.523", ['float' => 7.523,]],
-            'int 1'        => ["bool_option=1", ['bool_option' => 1,]],
-            'int 0'        => ["bool_option=0", ['bool_option' => 0,]],
-            'true'         => ["bool_option=true", ['bool_option' => true,]],
-            'yes'          => ["bool_option=yes", ['bool_option' => true,]],
-            'on'           => ["bool_option=on", ['bool_option' => true,]],
-            'false'        => ["bool_option=false", ['bool_option' => false,]],
-            'no'           => ["bool_option=no", ['bool_option' => false,]],
-            'off'          => ["bool_option=off", ['bool_option' => false,]],
-            'whitespace'   => [
+            'null' => ['option=null', ['option' => null,]],
+            'empty string' => ['option=', ['option' => '',]],
+            'string' => ['option=string', ['option' => 'string',]],
+            'integer' => ['integer=42', ['integer' => 42,]],
+            'float' => ['float=7.523', ['float' => 7.523,]],
+            'int 1' => ['bool_option=1', ['bool_option' => 1,]],
+            'int 0' => ['bool_option=0', ['bool_option' => 0,]],
+            'true' => ['bool_option=true', ['bool_option' => true,]],
+            'yes' => ['bool_option=yes', ['bool_option' => true,]],
+            'on' => ['bool_option=on', ['bool_option' => true,]],
+            'false' => ['bool_option=false', ['bool_option' => false,]],
+            'no' => ['bool_option=no', ['bool_option' => false,]],
+            'off' => ['bool_option=off', ['bool_option' => false,]],
+            'whitespace' => [
                 "whitespace= \tlong string\t\t  \tparts\t  ",
                 ['whitespace' => 'long string parts',],
             ],
@@ -36,11 +35,11 @@ class CRM_RcBase_Processor_ConfigTest extends TestCase
     public function provideHeaders()
     {
         return [
-            'ini+headers, process headers'          => [
+            'ini+headers, process headers' => [
                 "[Main]\noption_1=string\noption_2=176\n[Other config]\ndebug=off",
                 true,
                 [
-                    'Main'         => [
+                    'Main' => [
                         'option_1' => 'string',
                         'option_2' => 176,
                     ],
@@ -55,25 +54,25 @@ class CRM_RcBase_Processor_ConfigTest extends TestCase
                 [
                     'option_1' => 'string',
                     'option_2' => 176,
-                    'debug'    => false,
+                    'debug' => false,
                 ],
             ],
-            'no headers but process headers'        => [
+            'no headers but process headers' => [
                 "option_1=string\noption_2=176\ndebug=off",
                 true,
                 [
                     'option_1' => 'string',
                     'option_2' => 176,
-                    'debug'    => false,
+                    'debug' => false,
                 ],
             ],
-            'no headers and dont process headers'   => [
+            'no headers and dont process headers' => [
                 "option_1=string\noption_2=176\ndebug=off",
                 false,
                 [
                     'option_1' => 'string',
                     'option_2' => 176,
-                    'debug'    => false,
+                    'debug' => false,
                 ],
             ],
         ];
@@ -113,9 +112,9 @@ class CRM_RcBase_Processor_ConfigTest extends TestCase
      */
     public function testParseInvalidStringThrowsException()
     {
-        $ini_string = "options=off second=no newline";
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("Failed to parse ini string", "Invalid exception message.");
+        $ini_string = 'options=off second=no newline';
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage('Failed to parse ini string', 'Invalid exception message.');
         CRM_RcBase_Processor_Config::parseIniString($ini_string);
     }
 
@@ -124,7 +123,7 @@ class CRM_RcBase_Processor_ConfigTest extends TestCase
      */
     public function testNormalScanningMode()
     {
-        $ini_string = "bool=true";
+        $ini_string = 'bool=true';
         $expected = ['bool' => '1',];
         $result = CRM_RcBase_Processor_Config::parseIniString($ini_string, true, INI_SCANNER_NORMAL);
         $this->assertSame($expected, $result, 'Failed to parse ini string');
@@ -135,7 +134,7 @@ class CRM_RcBase_Processor_ConfigTest extends TestCase
      */
     public function testTypedScanningMode()
     {
-        $ini_string = "bool=on";
+        $ini_string = 'bool=on';
         $expected = ['bool' => true,];
         $result = CRM_RcBase_Processor_Config::parseIniString($ini_string, true, INI_SCANNER_TYPED);
         $this->assertSame($expected, $result, 'Failed to parse ini string');
@@ -148,7 +147,7 @@ class CRM_RcBase_Processor_ConfigTest extends TestCase
     {
         $filename = __DIR__.'/test.ini';
         $expected = [
-            'Main'         => [
+            'Main' => [
                 'option_1' => 'string',
                 'option_2' => 176,
             ],
@@ -167,7 +166,7 @@ class CRM_RcBase_Processor_ConfigTest extends TestCase
     {
         $filename = __DIR__.'/comment.ini';
         $expected = [
-            'Main'         => [
+            'Main' => [
                 'option_1' => 'string',
             ],
             'Other config' => [
@@ -184,9 +183,8 @@ class CRM_RcBase_Processor_ConfigTest extends TestCase
     public function testMissingIniFileThrowsException()
     {
         $filename = __DIR__.'/non-existent.ini';
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("Failed to parse ini file", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage('Failed to parse ini file', 'Invalid exception message.');
         CRM_RcBase_Processor_Config::parseIniFile($filename);
     }
-
 }

--- a/tests/phpunit/CRM/RcBase/Processor/JSONTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/JSONTest.php
@@ -18,16 +18,16 @@ class CRM_RcBase_Processor_JSONTest extends TestCase
     public function provideValidJson()
     {
         return [
-            'empty string'     => ['""', ''],
-            'empty object'     => ['{}', null],
-            'empty array'      => ['[]', null],
-            'null'             => ['null', null],
-            'string'           => ['"some string"', 'some string'],
-            'integer'          => ['5', 5],
-            'float'            => ['-21.984', -21.984],
-            'bool'             => ['false', false],
-            'array'            => ['["string 1","string 2"]', ['string 1', 'string 2']],
-            'complex'          => [
+            'empty string' => ['""', ''],
+            'empty object' => ['{}', null],
+            'empty array' => ['[]', null],
+            'null' => ['null', null],
+            'string' => ['"some string"', 'some string'],
+            'integer' => ['5', 5],
+            'float' => ['-21.984', -21.984],
+            'bool' => ['false', false],
+            'array' => ['["string 1","string 2"]', ['string 1', 'string 2']],
+            'complex' => [
                 '{"0":"string","1":"5","2":5,"3":-5,"4":1.1,"5":true,"field_1":"value_2","field_2":"value_2","6":["a","b","c"],"utf-8":"éáÜŐ"}',
                 [
                     'string',
@@ -39,24 +39,24 @@ class CRM_RcBase_Processor_JSONTest extends TestCase
                     'field_1' => 'value_2',
                     'field_2' => 'value_2',
                     ['a', 'b', 'c'],
-                    'utf-8'   => 'éáÜŐ',
+                    'utf-8' => 'éáÜŐ',
                 ],
             ],
             'need to sanitize' => [
                 '{"field\t\t_1  ":"<script>value</script>","   field_2":"value_2\n\n"}',
                 [
                     'field _1' => 'value',
-                    'field_2'  => 'value_2',
+                    'field_2' => 'value_2',
                 ],
             ],
-            'whitespace'       => [
+            'whitespace' => [
                 '{"\n   field_1   "  :  "\t\t\tvalue_1","field_2":"value_2"}',
                 [
                     'field_1' => 'value_1',
                     'field_2' => 'value_2',
                 ],
             ],
-            'UTF-8'            => [
+            'UTF-8' => [
                 '{"ÖÜÓŐÚÉÁŰÍ": "öüóőúéáűí"}',
                 ['ÖÜÓŐÚÉÁŰÍ' => 'öüóőúéáűí'],
             ],
@@ -83,14 +83,14 @@ class CRM_RcBase_Processor_JSONTest extends TestCase
     public function testInvalidJsonThrowsException()
     {
         $json = '["string 1"=,"string 2"]';
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("Invalid JSON received", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage('Invalid JSON received', 'Invalid exception message.');
         CRM_RcBase_Processor_JSON::parse($json);
     }
 
     public function testParseDataStream()
     {
-        $base64_enc = "eyLDlsOcw5PFkMOaw4nDgcWww40iOiAiw7bDvMOzxZHDusOpw6HFscOtIn0K";
+        $base64_enc = 'eyLDlsOcw5PFkMOaw4nDgcWww40iOiAiw7bDvMOzxZHDusOpw6HFscOtIn0K';
         $expected = ['ÖÜÓŐÚÉÁŰÍ' => 'öüóőúéáűí'];
         $result = CRM_RcBase_Processor_JSON::parseStream('data://text/plain;base64,'.$base64_enc);
         $this->assertSame($expected, $result, 'Invalid JSON returned.');
@@ -99,15 +99,15 @@ class CRM_RcBase_Processor_JSONTest extends TestCase
     public function testParseFileStream()
     {
         $expected = [
-            'string'  => 'some string',
-            1         => '5',
-            2         => 5,
-            3         => -5,
-            4         => 1.1,
-            5         => true,
+            'string' => 'some string',
+            1 => '5',
+            2 => 5,
+            3 => -5,
+            4 => 1.1,
+            5 => true,
             'field_1' => 'value_2',
             'field_2' => 'value_2',
-            6         =>
+            6 =>
                 [
                     0 => 'a',
                     1 => 'b',
@@ -120,8 +120,8 @@ class CRM_RcBase_Processor_JSONTest extends TestCase
 
     public function testFailedParseStreamThrowsException()
     {
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("Failed to open stream", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage('Failed to open stream', 'Invalid exception message.');
         CRM_RcBase_Processor_JSON::parseStream('file://'.__DIR__.'/non-existent.json');
     }
 
@@ -134,8 +134,8 @@ class CRM_RcBase_Processor_JSONTest extends TestCase
             -5,
             1.1,
             true,
-            'field_1'   => 'value_2',
-            'field_2'   => 'value_2',
+            'field_1' => 'value_2',
+            'field_2' => 'value_2',
             ['a', 'b', 'c'],
             'ÖÜÓŐÚÉÁŰÍ' => 'öüóőúéáűí',
         ];
@@ -165,12 +165,12 @@ class CRM_RcBase_Processor_JSONTest extends TestCase
             'field_1' => 'value_2',
             'field_2' => 'value_2',
             ['a', 'b', 'c'],
-            'utf-8'   => 'éáÜŐ',
+            'utf-8' => 'éáÜŐ',
         ];
 
         // Register Mock wrapper
-        stream_wrapper_unregister("php");
-        stream_wrapper_register("php", "CRM_RcBase_Test_MockPhpStream");
+        stream_wrapper_unregister('php');
+        stream_wrapper_register('php', 'CRM_RcBase_Test_MockPhpStream');
 
         // Feed JSON to stream
         file_put_contents('php://input', $json);
@@ -180,5 +180,4 @@ class CRM_RcBase_Processor_JSONTest extends TestCase
 
         $this->assertSame($expected, $result, 'Invalid JSON returned.');
     }
-
 }

--- a/tests/phpunit/CRM/RcBase/Processor/UrlEncodedFormTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/UrlEncodedFormTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class CRM_RcBase_Processor_UrlEncodedFormTest extends TestCase
 {
-
     public function testParseGet()
     {
         unset($_GET);
@@ -48,5 +47,4 @@ class CRM_RcBase_Processor_UrlEncodedFormTest extends TestCase
         $_POST = $post;
         $this->assertSame($post_sanitized, CRM_RcBase_Processor_UrlEncodedForm::parsePost(), 'Invalid data returned.');
     }
-
 }

--- a/tests/phpunit/CRM/RcBase/Processor/XMLTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/XMLTest.php
@@ -53,18 +53,18 @@ class CRM_RcBase_Processor_XMLTest extends TestCase
 XML;
         $expected = [
             'movie' => [
-                'title'       => 'PHP: Behind the Parser',
-                'utf-8'       => 'öüóőúéáűíÖÜÓŐÚÉÁŰ',
-                'urlencode'   => '%C3%B6%C3%BC%C3%B3%C5%91%C3%BA',
-                'characters'  => [
+                'title' => 'PHP: Behind the Parser',
+                'utf-8' => 'öüóőúéáűíÖÜÓŐÚÉÁŰ',
+                'urlencode' => '%C3%B6%C3%BC%C3%B3%C5%91%C3%BA',
+                'characters' => [
                     'character' => [
                         ['name' => 'Ms. Coder', 'actor' => 'Onlivia Áctőré',],
                         ['name' => 'Mr. Coder', 'actor' => 'El ActÓr',],
                     ],
                 ],
-                'plot'        => 'So, this language. It\'s like, a programming language. Or is it a scripting language? All is revealed in this thrilling horror spoof of a documentary.',
+                'plot' => 'So, this language. It\'s like, a programming language. Or is it a scripting language? All is revealed in this thrilling horror spoof of a documentary.',
                 'great-lines' => ['line' => 'PHP solves all my web problems',],
-                'rating'      => ['7', '5',],
+                'rating' => ['7', '5',],
             ],
         ];
         $result = CRM_RcBase_Processor_XML::parse($xml_string);
@@ -121,8 +121,8 @@ XML;
     public function testInvalidXmlThrowsException()
     {
         $invalid_xml = '<?xml version="1.0"?><movies><movie><title>Star Wars</title>';
-        $this->expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        $this->expectExceptionMessage("Invalid XML received", "Invalid exception message.");
+        $this->expectException(CRM_Core_Exception::class, 'Invalid exception class.');
+        $this->expectExceptionMessage('Invalid XML received', 'Invalid exception message.');
         CRM_RcBase_Processor_XML::parse($invalid_xml);
     }
 
@@ -131,11 +131,11 @@ XML;
         $expected = [
             'movie' => [
                 [
-                    'title'      => 'Star Wars',
+                    'title' => 'Star Wars',
                     'characters' => ['character' => ['Anakin Skywalker', 'Palpatine']],
                 ],
                 [
-                    'title'      => 'Harry Potter',
+                    'title' => 'Harry Potter',
                     'characters' => ['character' => ['Harry Potter', 'Voldemort']],
                 ],
             ],
@@ -187,24 +187,24 @@ XML;
 XML;
         $expected = [
             'movie' => [
-                'title'       => 'PHP: Behind the Parser',
-                'utf-8'       => 'öüóőúéáűíÖÜÓŐÚÉÁŰ',
-                'urlencode'   => '%C3%B6%C3%BC%C3%B3%C5%91%C3%BA',
-                'characters'  => [
+                'title' => 'PHP: Behind the Parser',
+                'utf-8' => 'öüóőúéáűíÖÜÓŐÚÉÁŰ',
+                'urlencode' => '%C3%B6%C3%BC%C3%B3%C5%91%C3%BA',
+                'characters' => [
                     'character' => [
                         ['name' => 'Ms. Coder', 'actor' => 'Onlivia Áctőré',],
                         ['name' => 'Mr. Coder', 'actor' => 'El ActÓr',],
                     ],
                 ],
-                'plot'        => 'So, this language. It\'s like, a programming language. Or is it a scripting language? All is revealed in this thrilling horror spoof of a documentary.',
+                'plot' => 'So, this language. It\'s like, a programming language. Or is it a scripting language? All is revealed in this thrilling horror spoof of a documentary.',
                 'great-lines' => ['line' => 'PHP solves all my web problems',],
-                'rating'      => ['7', '5',],
+                'rating' => ['7', '5',],
             ],
         ];
 
         // Register Mock wrapper
-        stream_wrapper_unregister("php");
-        stream_wrapper_register("php", "CRM_RcBase_Test_MockPhpStream");
+        stream_wrapper_unregister('php');
+        stream_wrapper_register('php', 'CRM_RcBase_Test_MockPhpStream');
 
         // Feed JSON to stream
         file_put_contents('php://input', $xml);
@@ -213,7 +213,7 @@ XML;
         $result = CRM_RcBase_Processor_XML::parsePost();
 
         // Restore original wrapper
-        stream_wrapper_restore("php");
+        stream_wrapper_restore('php');
 
         $this->assertSame($expected, $result, 'Invalid XML returned.');
     }
@@ -228,7 +228,7 @@ XML;
 <foo>&xxe;<title>Star Wars</title></foo>
 XML;
         $expected = [
-            'xxe'   => ['xxe' => null,],
+            'xxe' => ['xxe' => null,],
             'title' => 'Star Wars',
         ];
 
@@ -236,5 +236,4 @@ XML;
 
         $this->assertSame($expected, $result, 'Invalid XML returned.');
     }
-
 }

--- a/tests/phpunit/CRM/RcBase/Test/MockPhpStreamTest.php
+++ b/tests/phpunit/CRM/RcBase/Test/MockPhpStreamTest.php
@@ -18,10 +18,10 @@ class CRM_RcBase_Test_MockPhpStreamTest extends TestCase
     public function provideStreams()
     {
         return [
-            'std in'    => ['stdin'],
-            'std out'   => ['stdout'],
+            'std in' => ['stdin'],
+            'std out' => ['stdout'],
             'std error' => ['stderr'],
-            'input'     => ['input'],
+            'input' => ['input'],
         ];
     }
 
@@ -33,22 +33,21 @@ class CRM_RcBase_Test_MockPhpStreamTest extends TestCase
     public function testCheckOperation($stream)
     {
         // Register Mock wrapper
-        stream_wrapper_unregister("php");
-        stream_wrapper_register("php", "CRM_RcBase_Test_MockPhpStream");
+        stream_wrapper_unregister('php');
+        stream_wrapper_register('php', 'CRM_RcBase_Test_MockPhpStream');
 
         // Write & read data
-        $data = "original";
+        $data = 'original';
         file_put_contents("php://${stream}", $data);
         $result = file_get_contents("php://${stream}");
         $this->assertSame($data, $result, 'Invalid data returned.');
 
         // Update data
-        $data = "changed";
+        $data = 'changed';
         file_put_contents('php://input', $data);
         $result_changed = file_get_contents('php://input');
         $this->assertSame($data, $result_changed, 'Invalid data returned.');
 
         $this->assertNotSame($result, $result_changed, 'Result not changed.');
     }
-
 }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,12 +1,14 @@
 <?php
 
+use Composer\Autoload\ClassLoader;
+
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable
 // Allow autoloading of PHPUnit helper classes in this extension.
-$loader = new \Composer\Autoload\ClassLoader();
+$loader = new ClassLoader();
 $loader->add('CRM_', __DIR__);
 $loader->add('Civi\\', __DIR__);
 $loader->add('api_', __DIR__);
@@ -20,44 +22,46 @@ $loader->register();
  *   The rest of the command to send.
  * @param string $decode
  *   Ex: 'json' or 'phpcode'.
+ *
  * @return string
  *   Response output (if the command executed normally).
  * @throws \RuntimeException
  *   If the command terminates abnormally.
  */
-function cv($cmd, $decode = 'json') {
-  $cmd = 'cv ' . $cmd;
-  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
-  $oldOutput = getenv('CV_OUTPUT');
-  putenv("CV_OUTPUT=json");
+function cv($cmd, $decode = 'json')
+{
+    $cmd = 'cv '.$cmd;
+    $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => STDERR];
+    $oldOutput = getenv('CV_OUTPUT');
+    putenv('CV_OUTPUT=json');
 
-  // Execute `cv` in the original folder. This is a work-around for
-  // phpunit/codeception, which seem to manipulate PWD.
-  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+    // Execute `cv` in the original folder. This is a work-around for
+    // phpunit/codeception, which seem to manipulate PWD.
+    $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
 
-  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
-  putenv("CV_OUTPUT=$oldOutput");
-  fclose($pipes[0]);
-  $result = stream_get_contents($pipes[1]);
-  fclose($pipes[1]);
-  if (proc_close($process) !== 0) {
-    throw new RuntimeException("Command failed ($cmd):\n$result");
-  }
-  switch ($decode) {
-    case 'raw':
-      return $result;
+    $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+    putenv("CV_OUTPUT=$oldOutput");
+    fclose($pipes[0]);
+    $result = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+    if (proc_close($process) !== 0) {
+        throw new RuntimeException("Command failed ($cmd):\n$result");
+    }
+    switch ($decode) {
+        case 'raw':
+            return $result;
 
-    case 'phpcode':
-      // If the last output is /*PHPCODE*/, then we managed to complete execution.
-      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
-        throw new \RuntimeException("Command failed ($cmd):\n$result");
-      }
-      return $result;
+        case 'phpcode':
+            // If the last output is /*PHPCODE*/, then we managed to complete execution.
+            if (substr(trim($result), 0, 12) !== '/*BEGINPHP*/' || substr(trim($result), -10) !== '/*ENDPHP*/') {
+                throw new RuntimeException("Command failed ($cmd):\n$result");
+            }
+            return $result;
 
-    case 'json':
-      return json_decode($result, 1);
+        case 'json':
+            return json_decode($result, 1);
 
-    default:
-      throw new RuntimeException("Bad decoder format ($decode)");
-  }
+        default:
+            throw new RuntimeException("Bad decoder format ($decode)");
+    }
 }


### PR DESCRIPTION
Format code with the `php-cs-fixer` tool.
Command used for formatting: `php-cs-fixer fix --rules=@PSR2`

`.php_cs.dist` config file was needed to add for CI to work.
Probably it is possible to make it work without this config file, but this seemed the easy way.

Also added the dependency for unit tests, so it requires the code-style to succeed before starting these tests.