### PR TITLE
Settings tests

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -16,8 +16,8 @@
         <url desc="Support">https://github.com/reflexive-communications/rc-base/issues</url>
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2021-04-15</releaseDate>
-    <version>0.8.0</version>
+    <releaseDate>2021-04-16</releaseDate>
+    <version>0.8.1</version>
     <develStage>alpha</develStage>
     <compatibility>
         <ver>5.0</ver>


### PR DESCRIPTION
Extra tests to cover invalid domain and not empty contact id branches in `CRM_RcBase_Api_Get::settingValue()`