### PR TITLE
SMTP API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.phpunit.result.cache
+/.php-cs-fixer.cache
+/coverage/

--- a/CRM/RcBase/Processor/UrlEncodedForm.php
+++ b/CRM/RcBase/Processor/UrlEncodedForm.php
@@ -9,7 +9,6 @@
  */
 class CRM_RcBase_Processor_UrlEncodedForm
 {
-
     /**
      * Parse GET request parameters
      *

--- a/CRM/RcBase/Processor/XML.php
+++ b/CRM/RcBase/Processor/XML.php
@@ -9,7 +9,6 @@
  */
 class CRM_RcBase_Processor_XML
 {
-
     /**
      * Parse XML string
      *

--- a/Civi/Api4/Action/Setting/GetSmtpConfig.php
+++ b/Civi/Api4/Action/Setting/GetSmtpConfig.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Civi\Api4\Action\Setting;
+
+use Civi;
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Setting;
+use Throwable;
+
+/**
+ * Get SMTP configs
+ * Wrapper for Settings.Get +s mailing_backend
+ */
+class GetSmtpConfig extends AbstractAction
+{
+    /**
+     * Map configs to Civi config names
+     */
+    public const CONFIGS_MAP
+        = [
+            'server' => 'smtpServer',
+            'port' => 'smtpPort',
+            'user' => 'smtpUsername',
+            'pass' => 'smtpPassword',
+            'need_auth' => 'smtpAuth',
+        ];
+
+    /**
+     * Name of config to return
+     *
+     * @var string
+     */
+    protected $config = '';
+
+    /**
+     * @inheritDoc
+     */
+    public function _run(Result $result)
+    {
+        $configs = [];
+
+        if (!$this->validateParams()) {
+            $result[] = $this->error(sprintf('Not allowed config: %s', $this->config));
+            return;
+        }
+
+        try {
+            $settings = Setting::get()
+                ->addSelect('mailing_backend')
+                ->execute();
+        } catch (Throwable $ex) {
+            $result[] = $this->error($ex->getMessage());
+            return;
+        }
+
+        if (count($settings) != 1) {
+            $result[] = $this->error('Failed to retrieve mailing config');
+            return;
+        }
+
+        // Decrypt password
+        $settings[0]['value']['smtpPassword'] = Civi::service('crypto.token')->decrypt($settings[0]['value']['smtpPassword'], ['plain', 'CRED']);
+
+        // No config -> return all
+        if ($this->config === '') {
+            foreach (self::CONFIGS_MAP as $name => $civi_name) {
+                $configs[$name] = $settings[0]['value'][$civi_name];
+            }
+        } else {
+            $configs[$this->config] = $settings[0]['value'][self::CONFIGS_MAP[$this->config]];
+        }
+
+        $result[] = $configs;
+    }
+
+    /**
+     * Validate parameters
+     *
+     * @return bool Success
+     */
+    protected function validateParams(): bool
+    {
+        if ($this->config === '' || array_key_exists($this->config, self::CONFIGS_MAP)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Format error message
+     *
+     * @param string $message Error message
+     *
+     * @return array
+     */
+    protected function error(string $message): array
+    {
+        return [
+            'is_error' => true,
+            'error_message' => $message,
+        ];
+    }
+}

--- a/Civi/Api4/Action/Setting/GetSmtpConfig.php
+++ b/Civi/Api4/Action/Setting/GetSmtpConfig.php
@@ -31,7 +31,7 @@ class GetSmtpConfig extends AbstractAction
      *
      * @var string
      */
-    protected $config = '';
+    protected string $config = '';
 
     /**
      * @inheritDoc

--- a/Civi/Api4/Action/Setting/GetSmtpConfig.php
+++ b/Civi/Api4/Action/Setting/GetSmtpConfig.php
@@ -11,7 +11,8 @@ use Throwable;
 /**
  * Get SMTP config
  *
- * Wrapper for Settings.Get +s mailing_backend
+ * Wrapper for Settings.Get +s mailing_backend, more convenient to use on the CLI,
+ * also decrypts encrypted SMTP password.
  */
 class GetSmtpConfig extends AbstractAction
 {

--- a/Civi/Api4/Action/Setting/GetSmtpConfig.php
+++ b/Civi/Api4/Action/Setting/GetSmtpConfig.php
@@ -9,7 +9,8 @@ use Civi\Api4\Setting;
 use Throwable;
 
 /**
- * Get SMTP configs
+ * Get SMTP config
+ *
  * Wrapper for Settings.Get +s mailing_backend
  */
 class GetSmtpConfig extends AbstractAction
@@ -28,6 +29,15 @@ class GetSmtpConfig extends AbstractAction
 
     /**
      * Name of config to return
+     *
+     * Available configs:
+     * server (SMTP server URL),
+     * port (SMTP server port),
+     * user (SMTP username),
+     * pass (SMTP password),
+     * need_auth (is authentication required).
+     *
+     * If left empty, it will return all configs.
      *
      * @var string
      */

--- a/Civi/Api4/Action/Setting/SetSmtpConfig.php
+++ b/Civi/Api4/Action/Setting/SetSmtpConfig.php
@@ -2,6 +2,7 @@
 
 namespace Civi\Api4\Action\Setting;
 
+use API_Exception;
 use Civi;
 use Civi\Api4\Generic\AbstractAction;
 use Civi\Api4\Generic\Result;
@@ -57,33 +58,68 @@ class SetSmtpConfig extends AbstractAction
      */
     public function _run(Result $result)
     {
-        $configs = [];
+        $new = [];
 
         if (!empty($this->server)) {
-            $configs['smtpServer'] = $this->server;
+            $new['smtpServer'] = $this->server;
         }
         if (!empty($this->port)) {
-            $configs['smtpPort'] = $this->port;
+            $new['smtpPort'] = (string)$this->port;
         }
         if (!empty($this->user)) {
-            $configs['smtpUsername'] = $this->user;
+            $new['smtpUsername'] = $this->user;
         }
         if (!empty($this->pass)) {
             // Encrypt password
-            $configs['smtpPassword'] = Civi::service('crypto.token')->encrypt($this->pass, 'CRED');
+            $new['smtpPassword'] = Civi::service('crypto.token')->encrypt($this->pass, 'CRED');
         }
         if (!is_null($this->needAuth)) {
-            $configs['smtpAuth'] = $this->needAuth;
+            if ($this->needAuth) {
+                $new['smtpAuth'] = "1";
+            } else {
+                $new['smtpAuth'] = "0";
+            }
         }
 
         // Nothing to set
-        if (empty($configs)) {
+        if (empty($new)) {
             return;
         }
 
         try {
+            $configs = Setting::get()
+                ->addSelect('mailing_backend')
+                ->execute();
+            if (count($configs) != 1 || !array_key_exists('value', $configs[0])) {
+                throw new API_Exception('Failed to get old configs');
+            }
+            $old = $configs[0]['value'];
+
+            $merged = array_merge($old, $new);
+
+            // If both passwords are encrypted, we have to compare the plain-text passwords
+            // Ciphertext passwords always differ, even if plain-texts are the same
+            $old_pass = $old['smtpPassword'] ?? "";
+            $merged_pass = $merged['smtpPassword'] ?? "";
+            if (($old_pass != $merged_pass)
+                && !Civi::service('crypto.token')->isPlainText($old_pass)
+                && !Civi::service('crypto.token')->isPlainText($merged_pass)
+                && (Civi::service('crypto.token')->decrypt($old_pass) == Civi::service('crypto.token')->decrypt($merged_pass))
+            ) {
+                // Same plain-text password -> use old value (avoid unnecessary change, even if it would have the same effect)
+                if ($old_pass != "") {
+                    $merged['smtpPassword'] = $old_pass;
+                }
+            }
+
+            // Merging new values have not changed the array -> there is no change
+            if ($old === $merged) {
+                $result[] = ['no_change' => true,];
+                return;
+            }
+
             $results = Setting::set()
-                ->addValue('mailing_backend', $configs)
+                ->addValue('mailing_backend', $merged)
                 ->execute();
         } catch (Throwable $ex) {
             $result[] = $this->error($ex->getMessage());
@@ -95,7 +131,7 @@ class SetSmtpConfig extends AbstractAction
             return;
         }
 
-        $result[] = $configs;
+        $result[] = $merged;
     }
 
     /**

--- a/Civi/Api4/Action/Setting/SetSmtpConfig.php
+++ b/Civi/Api4/Action/Setting/SetSmtpConfig.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Civi\Api4\Action\Setting;
+
+use Civi;
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Setting;
+use Throwable;
+
+/**
+ * Set SMTP configs
+ *
+ * Wrapper for Setting.set +v mailing_backend={config_json}. It is designed for easier use on the CLI.
+ * Also encrypts the SMTP password.
+ */
+class SetSmtpConfig extends AbstractAction
+{
+    /**
+     * SMTP server URL
+     *
+     * @var string
+     */
+    protected string $server = '';
+
+    /**
+     * SMTP server port
+     *
+     * @var int
+     */
+    protected int $port = 0;
+
+    /**
+     * SMTP user
+     *
+     * @var string
+     */
+    protected string $user = '';
+
+    /**
+     * SMTP password
+     *
+     * @var string
+     */
+    protected string $pass = '';
+
+    /**
+     * Need to authenticate on SMTP server
+     *
+     * @var bool
+     */
+    protected ?bool $needAuth = null;
+
+
+    /**
+     * @inheritDoc
+     */
+    public function _run(Result $result)
+    {
+        $configs = [];
+
+        if (!empty($this->server)) {
+            $configs['smtpServer'] = $this->server;
+        }
+        if (!empty($this->port)) {
+            $configs['smtpPort'] = $this->port;
+        }
+        if (!empty($this->user)) {
+            $configs['smtpUsername'] = $this->user;
+        }
+        if (!empty($this->pass)) {
+            // Encrypt password
+            $configs['smtpPassword'] = Civi::service('crypto.token')->encrypt($this->pass, 'CRED');
+        }
+        if (!is_null($this->needAuth)) {
+            $configs['smtpAuth'] = $this->needAuth;
+        }
+
+        // Nothing to set
+        if (empty($configs)) {
+            return;
+        }
+
+        try {
+            $results = Setting::set()
+                ->addValue('mailing_backend', $configs)
+                ->execute();
+        } catch (Throwable $ex) {
+            $result[] = $this->error($ex->getMessage());
+            return;
+        }
+
+        if (count($results) != 1) {
+            $result[] = $this->error('Failed to set mailing config');
+            return;
+        }
+
+        $result[] = $configs;
+    }
+
+    /**
+     * Format error message
+     *
+     * @param string $message Error message
+     *
+     * @return array
+     */
+    protected function error(string $message): array
+    {
+        return [
+            'is_error' => true,
+            'error_message' => $message,
+        ];
+    }
+}

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,47 @@
+# Developer Notes
+
+## Config aka. CRM\_RcBase\_Config
+
+This abstract class provides an interface for the db methods (civi config). The create, load, update, get, remove
+methods are implemented in this class. If you want to use this Config, you have to extend this class and implement the
+defaultConfiguration method. It is responsible for providing an extension specific default configuration that will be
+inserted to the settings database with the create method. The configuration is stored under a config specific key in the
+settings db. The prefix of this key has to be passed to the class constructor. The default configuration is inserted to
+the config database on extension install.
+
+**Concrete implementation example**
+
+```php
+class CRM_MyExtension_MyConfig extends CRM_RcBase_Config {
+    public function defaultConfiguration(): array {
+        return [
+            "important-key" => 1,
+        ];
+    }
+}
+```
+
+**Get current configuration**
+
+```php
+$config = new CRM_MyExtension_MyConfig("MyExtension_Key_Prefix");
+try {
+    $config->load();
+} catch (Exception $e) {
+    // It could happen if the dbhost is not configured well.
+}
+$configuration = $config->get();
+```
+
+**Update configuration**
+
+```php
+$config = new CRM_MyExtension_MyConfig("MyExtension_Key_Prefix");
+$newConfig = [
+    "important-key" => 2,
+    "new-key" => "Some new value",
+];
+if (!$config->update($newConfig)) {
+    // It could happen if the dbhost is not configured well.
+}
+```

--- a/README.md
+++ b/README.md
@@ -2,63 +2,54 @@
 
 ![CI](https://github.com/reflexive-communications/rc-base/workflows/CI/badge.svg)
 
-This extension does nothing, it is only required by some other extensions. It contains shared components, libraries.
-
-**Extra permissions available:**
-- access custom API: this can be used for an unprivileged CMS user to access custom API endpoints
+This extension does nothing, it's only required by some other extensions. It contains shared components, libraries.
 
 The extension is licensed under [AGPL-3.0](LICENSE.txt).
 
-### Config aka. CRM\_RcBase\_Config
+## Features
 
-This abstract class provides an interface for the db methods (civi config). The create, load, update, get, remove methods are implemented in this class. If you want to use this Config, you have to extend this class and implement the defaultConfiguration method. It is responsible for providing an extension specific default configuration that will be inserted to the settings database with the create method. The configuration is stored under a config specific key in the settings db. The prefix of this key has to be passed to the class constructor. The default configuration is inserted to the config database on extension install.
+### Extra permissions
 
-**Concrete implementation example**
+New CMS permissions:
 
-```php
-class CRM_MyExtension_MyConfig extends CRM_RcBase_Config {
-    public function defaultConfiguration(): array {
-        return [
-            "important-key" => 1,
-        ];
-    }
-}
-```
+- **access custom API**: this can be used for an unprivileged CMS user to access custom API endpoints
 
-**Get current configuration**
+### New API
 
-```php
-$config = new CRM_MyExtension_MyConfig("MyExtension_Key_Prefix");
-try {
-    $config->load();
-} catch (Exception $e) {
-    // It could happen if the dbhost is not configured well.
-}
-$configuration = $config->get();
-```
+#### New API actions are provided.
 
-**Update configuration**
+Below is a summary, for more details check the API Explorer.
 
-```php
-$config = new CRM_MyExtension_MyConfig("MyExtension_Key_Prefix");
-$newConfig = [
-    "important-key" => 2,
-    "new-key" => "Some new value",
-];
-if (!$config->update($newConfig)) {
-    // It could happen if the dbhost is not configured well.
-}
-```
+- `Setting::getSmtpConfig`
+    - Returns current SMTP config nicely formatted. If SMTP password is encrypted, decrypted text is provided.
+    - You can select which config to return (or all)
+- `Setting::setSmtpConfig`
+    - Allows for more convenient setting of SMTP configs mainly on the CLI (terminal)
+    - If encryption is enabled, it will encrypt plain-text passwords
+    - Idempotent: checks first if the new config is different than the old one, and changes only if it's needed
+
+#### API wrappers
+
+Generic PHP classes that wrap standard Civi APIv4.
+
+### Processor
+
+Generic PHP IO processors for JSON, URL-encoded, XML or INI files or streams.
+
+### Civi::Settings wrapper
+
+A Base class (`CRM_RcBase_Config`) that wraps `Civi::Settings()` for easier use. For details check
+the [Developer Notes](DEVELOPER.md).
 
 ## Requirements
 
-* PHP v7.3+
-* CiviCRM ((5.24 might work below - not tested))
+* PHP v7.4+
+* CiviCRM (5.43 might work below - not tested)
 
 ## Installation
 
-Sysadmins and developers may clone the [Git](https://en.wikipedia.org/wiki/Git) repo for this extension and
-install it with the command-line tool [cv](https://github.com/civicrm/cv).
+Sysadmins and developers may clone the [Git](https://en.wikipedia.org/wiki/Git) repo for this extension and install it
+with the command-line tool [cv](https://github.com/civicrm/cv).
 
 ```bash
 git clone https://github.com/reflexive-communications/rc-base.git

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Below is a summary, for more details check the API Explorer.
 - `Setting::setSmtpConfig`
     - Allows for more convenient setting of SMTP configs mainly on the CLI (terminal)
     - If encryption is enabled, it will encrypt plain-text passwords
-    - Idempotent: checks first if the new config is different than the old one, and changes only if it's needed
+    - Idempotent: checks first and changes config only if it's needed, and report back if no change was done
 
 #### API wrappers
 

--- a/info.xml
+++ b/info.xml
@@ -16,8 +16,8 @@
         <url desc="Support">https://github.com/reflexive-communications/rc-base/issues</url>
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2021-12-06</releaseDate>
-    <version>0.11.0</version>
+    <releaseDate>2022-01-13</releaseDate>
+    <version>0.12.0</version>
     <develStage>alpha</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/rc_base.civix.php
+++ b/rc_base.civix.php
@@ -8,9 +8,9 @@
  */
 class CRM_RcBase_ExtensionUtil
 {
-    const SHORT_NAME = 'rc_base';
-    const LONG_NAME = 'rc-base';
-    const CLASS_PREFIX = 'CRM_RcBase';
+    public const SHORT_NAME = 'rc_base';
+    public const LONG_NAME = 'rc-base';
+    public const CLASS_PREFIX = 'CRM_RcBase';
 
     /**
      * Translate a string using the extension's domain.

--- a/tests/phpunit/CRM/RcBase/Api4/Action/Setting/SmtpConfigTest.php
+++ b/tests/phpunit/CRM/RcBase/Api4/Action/Setting/SmtpConfigTest.php
@@ -13,10 +13,9 @@ class CRM_RcBase_Api4_SmtpConfigTest extends CRM_RcBase_HeadlessTestCase
         = [
             'smtpServer' => 'smtp.example.com',
             'smtpPort' => '465',
-            'smtpAuth' => '1',
+            'smtpAuth' => false,
             'smtpUsername' => 'admin',
             'smtpPassword' => 'pass',
-            'smtpPasswordfdsf' => 'pass',
         ];
 
     /**
@@ -70,9 +69,75 @@ class CRM_RcBase_Api4_SmtpConfigTest extends CRM_RcBase_HeadlessTestCase
             ->setConfig('invalid_config')
             ->execute();
         self::assertCount(1, $smtp_configs, 'Failed to get configs');
-        self::assertArrayHasKey('is_error', $smtp_configs[0], "Missing is_error");
-        self::assertArrayHasKey('error_message', $smtp_configs[0], "Missing is_error");
+        self::assertArrayHasKey('is_error', $smtp_configs[0], 'Missing is_error');
+        self::assertArrayHasKey('error_message', $smtp_configs[0], 'Missing error_message');
         self::assertEquals(true, $smtp_configs[0]['is_error']);
         self::assertEquals('Not allowed config: invalid_config', $smtp_configs[0]['error_message']);
+    }
+
+    /**
+     * @return void
+     * @throws \API_Exception
+     * @throws \Civi\API\Exception\UnauthorizedException
+     */
+    public function testSetConfig()
+    {
+        $new_configs = [
+            'server' => 'other.smtp.example.com',
+            'port' => 112,
+            'need_auth' => true,
+            'user' => 'other_admin',
+            'pass' => 'other_pass',
+        ];
+
+        Setting::setSmtpConfig()
+            ->setServer($new_configs['server'])
+            ->setPort($new_configs['port'])
+            ->setUser($new_configs['user'])
+            ->setPass($new_configs['pass'])
+            ->setNeedAuth($new_configs['need_auth'])
+            ->execute();
+
+        $smtp_configs = Setting::get()
+            ->addSelect('mailing_backend')
+            ->execute();
+        self::assertCount(1, $smtp_configs, 'Failed to get configs');
+        self::assertArrayHasKey('value', $smtp_configs[0], 'Failed to get configs');
+        self::assertArrayHasKey('smtpServer', $smtp_configs[0]['value'], 'Missing config: smtpServer');
+        self::assertEquals($new_configs['server'], $smtp_configs[0]['value']['smtpServer']);
+        self::assertArrayHasKey('smtpPort', $smtp_configs[0]['value'], 'Missing config: smtpPort');
+        self::assertEquals($new_configs['port'], $smtp_configs[0]['value']['smtpPort']);
+        self::assertArrayHasKey('smtpAuth', $smtp_configs[0]['value'], 'Missing config: smtpAuth');
+        self::assertEquals($new_configs['need_auth'], $smtp_configs[0]['value']['smtpAuth']);
+        self::assertArrayHasKey('smtpUsername', $smtp_configs[0]['value'], 'Missing config: smtpUsername');
+        self::assertEquals($new_configs['user'], $smtp_configs[0]['value']['smtpUsername']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetNoParamsReturnEmpty()
+    {
+        $results = Setting::setSmtpConfig()
+            ->execute();
+        self::assertCount(0, $results, 'Not empty result set when no params to set');
+    }
+
+    /**
+     * @return void
+     */
+    public function testPasswordChange()
+    {
+        $new_pass = 'new_password';
+        Setting::setSmtpConfig()
+            ->setPass($new_pass)
+            ->execute();
+
+        $pass = Setting::getSmtpConfig()
+            ->setConfig('pass')
+            ->execute();
+        self::assertCount(1, $pass, 'Failed to get password');
+        self::assertArrayHasKey('pass', $pass[0], 'Failed to get password');
+        self::assertEquals($new_pass, $pass[0]['pass'], 'Failed to change password');
     }
 }

--- a/tests/phpunit/CRM/RcBase/Api4/Action/Setting/SmtpConfigTest.php
+++ b/tests/phpunit/CRM/RcBase/Api4/Action/Setting/SmtpConfigTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Civi\Api4\Setting;
+
+/**
+ * Test Get/Set SMTP Config API
+ *
+ * @group headless
+ */
+class CRM_RcBase_Api4_SmtpConfigTest extends CRM_RcBase_HeadlessTestCase
+{
+    public const DEFAULT_SMTP_CONFIG
+        = [
+            'smtpServer' => 'smtp.example.com',
+            'smtpPort' => '465',
+            'smtpAuth' => '1',
+            'smtpUsername' => 'admin',
+            'smtpPassword' => 'pass',
+            'smtpPasswordfdsf' => 'pass',
+        ];
+
+    /**
+     * @return void
+     * @throws \API_Exception
+     * @throws \Civi\API\Exception\UnauthorizedException
+     */
+    protected function setUp(): void
+    {
+        $results = Setting::set()
+            ->addValue('mailing_backend', self::DEFAULT_SMTP_CONFIG)
+            ->execute();
+        self::assertCount(1, $results, 'Failed to set default config');
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetAllConfig()
+    {
+        $smtp_configs = Setting::getSmtpConfig()->execute();
+
+        self::assertCount(1, $smtp_configs, 'Failed to get configs');
+        foreach (Civi\Api4\Action\Setting\GetSmtpConfig::CONFIGS_MAP as $name => $civi_name) {
+            self::assertArrayHasKey($name, $smtp_configs[0], "Missing config: ${name}");
+            self::assertEquals(self::DEFAULT_SMTP_CONFIG[$civi_name], $smtp_configs[0][$name]);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetOneConfig()
+    {
+        foreach (Civi\Api4\Action\Setting\GetSmtpConfig::CONFIGS_MAP as $name => $civi_name) {
+            $smtp_configs = Setting::getSmtpConfig()
+                ->setConfig($name)
+                ->execute();
+            self::assertCount(1, $smtp_configs, 'Failed to get configs');
+            self::assertArrayHasKey($name, $smtp_configs[0], "Missing config: ${name}");
+            self::assertEquals(self::DEFAULT_SMTP_CONFIG[$civi_name], $smtp_configs[0][$name]);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetInvalidNameReturnsError()
+    {
+        $smtp_configs = Setting::getSmtpConfig()
+            ->setConfig('invalid_config')
+            ->execute();
+        self::assertCount(1, $smtp_configs, 'Failed to get configs');
+        self::assertArrayHasKey('is_error', $smtp_configs[0], "Missing is_error");
+        self::assertArrayHasKey('error_message', $smtp_configs[0], "Missing is_error");
+        self::assertEquals(true, $smtp_configs[0]['is_error']);
+        self::assertEquals('Not allowed config: invalid_config', $smtp_configs[0]['error_message']);
+    }
+}

--- a/tests/phpunit/CRM/RcBase/Processor/JSONTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/JSONTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class CRM_RcBase_Processor_JSONTest extends TestCase
 {
-
     /**
      * Provide valid JSON
      *

--- a/tests/phpunit/CRM/RcBase/Processor/XMLTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/XMLTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class CRM_RcBase_Processor_XMLTest extends TestCase
 {
-
     /**
      * @throws \CRM_Core_Exception
      */

--- a/tests/phpunit/CRM/RcBase/Test/MockPhpStreamTest.php
+++ b/tests/phpunit/CRM/RcBase/Test/MockPhpStreamTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
  */
 class CRM_RcBase_Test_MockPhpStreamTest extends TestCase
 {
-
     /**
      * Provide streams for the php:// stream wrapper
      *


### PR DESCRIPTION
New API that wraps `Settings::Get->addSelect('mailing_backend')` and `Settings::Set()->addValue('mailing_backend', '')`.
Main reason is, since SMTP password encrpytion is featured (and used) in CiviCRM, having an encrypted password is only possible if we set it through the GUI (**Administer >> System Settings >> Outbound Email**).
This prevents the use `cv` (or other command-line tool) to manage SMTP credentials, which is essential for a CI/CD pipeline.

Using this API, plaintext passwords are encrypted. It's also idempotent, makes changes only if necessary, and reports back if no change was done.
Futhermore it was designed for easy use on the CLI.

Note: it *may* be possible to simulate the GUI-behaviour on command-line, but I find it quite cumbersome.