### PR TITLE
Setting Wrapper

### DIFF
--- a/CRM/RcBase/Config.php
+++ b/CRM/RcBase/Config.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @deprecated
+ */
 abstract class CRM_RcBase_Config
 {
     private $configName;

--- a/CRM/RcBase/Setting.php
+++ b/CRM/RcBase/Setting.php
@@ -1,0 +1,93 @@
+<?php
+
+use Civi\Api4\Setting;
+
+/**
+ * Settings Wrapper
+ *
+ * @package  rc-base
+ * @author   Sandor Semsey <sandor@es-progress.hu>
+ * @license  AGPL-3.0
+ */
+class CRM_RcBase_Setting
+{
+    /**
+     * Save setting in DB, create new entry if not exists
+     *
+     * @param string $name Setting name
+     * @param mixed $value Setting value
+     *
+     * @throws \CRM_Core_Exception
+     */
+    public static function save(string $name, $value): void
+    {
+        if (empty($name)) {
+            throw new CRM_Core_Exception('Missing setting name');
+        }
+
+        Civi::settings()->set($name, $value);
+
+        $saved = Civi::settings()->get($name);
+        if ($saved !== $value) {
+            throw new CRM_Core_Exception(sprintf('Failed to save setting: %s', $name));
+        }
+    }
+
+    /**
+     * Get setting value from DB
+     *
+     * @param string $name Setting name
+     *
+     * @return mixed Setting value
+     *
+     * @throws CRM_Core_Exception.
+     */
+    public static function get(string $name)
+    {
+        if (empty($name)) {
+            throw new CRM_Core_Exception('Missing setting name');
+        }
+
+        return Civi::settings()->get($name);
+    }
+
+    /**
+     * Remove setting from DB
+     *
+     * @param string $name Setting name
+     *
+     * @throws \API_Exception
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\API\Exception\UnauthorizedException
+     */
+    public static function remove(string $name)
+    {
+        if (empty($name)) {
+            throw new CRM_Core_Exception('Missing setting name');
+        }
+
+        // Search setting
+        $exists = false;
+        $settings = Setting::get()->execute();
+        foreach ($settings as $setting) {
+            if ($setting['name'] == $name) {
+                $exists = true;
+                break;
+            }
+        }
+
+        // Not found --> job done
+        if (!$exists) {
+            return;
+        }
+
+        $dao = new CRM_Core_DAO_Setting();
+        $dao->name = $name;
+        $dao->delete();
+        Civi::service('settings_manager')->flush();
+
+        if (!is_null(Civi::settings()->get($name))) {
+            throw new CRM_Core_Exception(sprintf('Failed to delete setting: %s', $name));
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Generic PHP IO processors for JSON, URL-encoded, XML or INI files or streams.
 A Base class (`CRM_RcBase_Config`) that wraps `Civi::Settings()` for easier use. For details check
 the [Developer Notes](DEVELOPER.md).
 
+### Settings
+Helper class (`CRM_RcBase_Setting`) for managing settings, basically a thin wrapper for `Civi::Settings()`.
+
 ## Requirements
 
 * PHP v7.4+

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ the [Developer Notes](DEVELOPER.md).
 
 ### Settings
 Helper class (`CRM_RcBase_Setting`) for managing settings, basically a thin wrapper for `Civi::Settings()`.
+You can encrypt sensitive data (only strings) with `CRM_RcBase_Setting::saveSecret()`.
+When retrieving saved setting with `CRM_RcBase_Setting::get()` setting values are automatically decrypted if it was encrypted.
 
 ## Requirements
 

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
         <url desc="Support">https://github.com/reflexive-communications/rc-base/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2022-04-16</releaseDate>
-    <version>1.2.0</version>
+    <releaseDate>2022-06-03</releaseDate>
+    <version>1.3.0</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/tests/phpunit/CRM/RcBase/SettingTest.php
+++ b/tests/phpunit/CRM/RcBase/SettingTest.php
@@ -37,6 +37,42 @@ class CRM_RcBase_SettingTest extends CRM_RcBase_HeadlessTestCase
      * @return void
      * @throws \CRM_Core_Exception
      */
+    public function testSaveSecret()
+    {
+        $name = 'secret-key';
+        $secret = 'topsecret';
+        CRM_RcBase_Setting::saveSecret($name, $secret);
+
+        $raw_value = Civi::settings()->get($name);
+        self::assertFalse(Civi::service('crypto.token')->isPlainText($raw_value), 'Secret was not encrypted');
+
+        $saved = CRM_RcBase_Setting::get($name);
+        self::assertSame($secret, $saved, 'Wrong secret returned');
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     */
+    public function testRotateSecret()
+    {
+        $name = 'rotate-secret-key';
+        $secret = 'original_pass';
+        CRM_RcBase_Setting::saveSecret($name, $secret);
+        $original_encrypted = Civi::settings()->get($name);
+        self::assertFalse(Civi::service('crypto.token')->isPlainText($original_encrypted), 'Secret was not encrypted');
+
+        CRM_RcBase_Setting::rotateSecret($name);
+        $rotated_encrypted = Civi::settings()->get($name);
+        self::assertFalse(Civi::service('crypto.token')->isPlainText($rotated_encrypted), 'Secret was not encrypted');
+
+        self::assertNotEquals($original_encrypted, $rotated_encrypted, 'Secret not rotated');
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     */
     public function testGetNonExistentReturnsNull()
     {
         self::assertNull(CRM_RcBase_Setting::get('non_existent_setting'));

--- a/tests/phpunit/CRM/RcBase/SettingTest.php
+++ b/tests/phpunit/CRM/RcBase/SettingTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_RcBase_SettingTest extends CRM_RcBase_HeadlessTestCase
+{
+    /**
+     * @return array
+     */
+    public function provideSettings(): array
+    {
+        return [
+            'string' => ['some string'],
+            'integer' => [42],
+            'float' => [13.67],
+            'bool' => [false],
+            'null' => [null],
+            'array' => [[1, 'text', 2 => 4, 3 => 'other string']],
+            'object' => [new CRM_RcBase_Setting()],
+        ];
+    }
+
+    /**
+     * @dataProvider provideSettings
+     * @throws \CRM_Core_Exception
+     */
+    public function testSave($value)
+    {
+        $name = 'test-config';
+        CRM_RcBase_Setting::save($name, $value);
+        $saved = CRM_RcBase_Setting::get($name);
+        self::assertSame($value, $saved, 'Wrong value returned');
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     */
+    public function testGetNonExistentReturnsNull()
+    {
+        self::assertNull(CRM_RcBase_Setting::get('non_existent_setting'));
+    }
+
+    /**
+     * @return void
+     * @throws \API_Exception
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\API\Exception\UnauthorizedException
+     */
+    public function testRemove()
+    {
+        self::assertEmpty(CRM_RcBase_Setting::save('remove-existent-setting', true));
+        self::assertEmpty(CRM_RcBase_Setting::remove('remove-existent-setting'));
+
+        self::assertEmpty(CRM_RcBase_Setting::remove('remove-non-existent-setting'));
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     */
+    public function testMissingNameThrowsExceptionOnSave()
+    {
+        self::expectException(CRM_Core_Exception::class);
+        self::expectExceptionMessage('Missing setting name');
+        CRM_RcBase_Setting::save('', 43);
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     */
+    public function testMissingNameThrowsExceptionOnGet()
+    {
+        self::expectException(CRM_Core_Exception::class);
+        self::expectExceptionMessage('Missing setting name');
+        CRM_RcBase_Setting::get('');
+    }
+
+    /**
+     * @return void
+     * @throws \API_Exception
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\API\Exception\UnauthorizedException
+     */
+    public function testMissingNameThrowsExceptionOnRemove()
+    {
+        self::expectException(CRM_Core_Exception::class);
+        self::expectExceptionMessage('Missing setting name');
+        CRM_RcBase_Setting::remove('');
+    }
+}


### PR DESCRIPTION
- Implement `CRM_RcBase_Setting` which is a wrapper for `Civi::settings()`
- support for encryption
- deprecate `CRM_RcBase_Config`