### PR TITLE
API: move Create, Update to new namespace

### DIFF
--- a/CRM/RcBase/Api/Create.php
+++ b/CRM/RcBase/Api/Create.php
@@ -7,6 +7,7 @@ use Civi\Api4\OptionValue;
  *
  * Wrapper around APIv4
  *
+ * @deprecated use \Civi\RcBase\ApiWrapper\Create instead
  * @package  rc-base
  * @author   Sandor Semsey <sandor@es-progress.hu>
  * @license  AGPL-3.0

--- a/CRM/RcBase/Api/Update.php
+++ b/CRM/RcBase/Api/Update.php
@@ -5,6 +5,7 @@
  *
  * Wrapper around APIv4
  *
+ * @deprecated use \Civi\RcBase\ApiWrapper\Update instead
  * @package  rc-base
  * @author   Sandor Semsey <sandor@es-progress.hu>
  * @license  AGPL-3.0

--- a/Civi/RcBase/ApiWrapper/Create.php
+++ b/Civi/RcBase/ApiWrapper/Create.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace Civi\RcBase\ApiWrapper;
+
+use Civi\Api4\OptionValue;
+use Civi\RcBase\Exception\APIException;
+use Civi\RcBase\Exception\InvalidArgumentException;
+use Civi\RcBase\Exception\MissingArgumentException;
+use CRM_RcBase_Api_Get;
+use Throwable;
+
+/**
+ * Common Create Actions
+ * Wrapper around APIv4
+ *
+ * @package  rc-base
+ * @author   Sandor Semsey <sandor@es-progress.hu>
+ * @license  AGPL-3.0
+ */
+class Create
+{
+    /**
+     * Add new entity
+     *
+     * @param string $entity Name of entity
+     * @param array $values Entity data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return int ID of created entity
+     * @throws \Civi\RcBase\Exception\APIException
+     */
+    public static function entity(string $entity, array $values = [], bool $check_permissions = false): int
+    {
+        try {
+            $results = civicrm_api4(
+                $entity,
+                'create',
+                [
+                    'values' => $values,
+                    'checkPermissions' => $check_permissions,
+                ]
+            );
+        } catch (Throwable $ex) {
+            throw new APIException($entity, 'create', $ex->getMessage());
+        }
+
+        if (count($results) < 1) {
+            throw new APIException($entity, 'create', 'Failed to create entity');
+        }
+
+        $id = ($results->first()['id']) ?? 0;
+        if ($id < 1) {
+            throw new APIException($entity, 'create', 'Not a valid ID returned');
+        }
+
+        return (int)$id;
+    }
+
+    /**
+     * Create new contact
+     *
+     * @param array $values Contact data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return int Contact ID
+     * @throws \Civi\RcBase\Exception\APIException
+     */
+    public static function contact(array $values = [], bool $check_permissions = false): int
+    {
+        return self::entity('Contact', $values, $check_permissions);
+    }
+
+    /**
+     * Add email to contact
+     *
+     * @param int $contact_id Contact ID
+     * @param array $values Email data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return int Email ID
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     */
+    public static function email(int $contact_id, array $values = [], bool $check_permissions = false): int
+    {
+        if ($contact_id < 1) {
+            throw new InvalidArgumentException('contact ID', 'ID must be positive');
+        }
+
+        $values['contact_id'] = $contact_id;
+
+        return self::entity('Email', $values, $check_permissions);
+    }
+
+    /**
+     * Add phone to contact
+     *
+     * @param int $contact_id Contact ID
+     * @param array $values Phone data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return int Phone ID
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     */
+    public static function phone(int $contact_id, array $values = [], bool $check_permissions = false): int
+    {
+        if ($contact_id < 1) {
+            throw new InvalidArgumentException('contact ID', 'ID must be positive');
+        }
+
+        $values['contact_id'] = $contact_id;
+
+        return self::entity('Phone', $values, $check_permissions);
+    }
+
+    /**
+     * Add address to contact
+     *
+     * @param int $contact_id Contact ID
+     * @param array $values Address data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return int Address ID
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     */
+    public static function address(int $contact_id, array $values = [], bool $check_permissions = false): int
+    {
+        if ($contact_id < 1) {
+            throw new InvalidArgumentException('contact ID', 'ID must be positive');
+        }
+
+        $values['contact_id'] = $contact_id;
+
+        return self::entity('Address', $values, $check_permissions);
+    }
+
+    /**
+     * Add relationship to contact
+     *
+     * @param int $contact_id Contact ID
+     * @param array $values Relationship data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return int Relationship ID
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     */
+    public static function relationship(int $contact_id, array $values = [], bool $check_permissions = false): int
+    {
+        if ($contact_id < 1) {
+            throw new InvalidArgumentException('contact ID', 'ID must be positive');
+        }
+
+        $values['contact_id_a'] = $contact_id;
+
+        return self::entity('Relationship', $values, $check_permissions);
+    }
+
+    /**
+     * Add contribution to contact
+     *
+     * @param int $contact_id Contact ID
+     * @param array $values Contribution data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return int Contribution ID
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     */
+    public static function contribution(int $contact_id, array $values = [], bool $check_permissions = false): int
+    {
+        if ($contact_id < 1) {
+            throw new InvalidArgumentException('contact ID', 'ID must be positive');
+        }
+
+        $values['contact_id'] = $contact_id;
+
+        return self::entity('Contribution', $values, $check_permissions);
+    }
+
+    /**
+     * Add activity to contact
+     *
+     * @param int $contact_id Contact ID
+     * @param array $values Activity data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return int Activity ID
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     */
+    public static function activity(int $contact_id, array $values = [], bool $check_permissions = false): int
+    {
+        if ($contact_id < 1) {
+            throw new InvalidArgumentException('contact ID', 'ID must be positive');
+        }
+
+        $values['target_contact_id'] = $contact_id;
+
+        return self::entity('Activity', $values, $check_permissions);
+    }
+
+    /**
+     * Add tag to contact
+     *
+     * @param int $contact_id Contact ID
+     * @param int $tag_id Tag ID
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return int EntityTag ID
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     */
+    public static function tagContact(int $contact_id, int $tag_id, bool $check_permissions = false): int
+    {
+        if ($contact_id < 1) {
+            throw new InvalidArgumentException('contact ID', 'ID must be positive');
+        }
+        if ($tag_id < 1) {
+            throw new InvalidArgumentException('tag ID', 'ID must be positive');
+        }
+
+        $values = [
+            'entity_table' => 'civicrm_contact',
+            'entity_id' => $contact_id,
+            'tag_id' => $tag_id,
+        ];
+
+        return self::entity('EntityTag', $values, $check_permissions);
+    }
+
+    /**
+     * Create group
+     *
+     * @param array $values Group data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return int Group ID
+     * @throws \Civi\RcBase\Exception\APIException
+     */
+    public static function group(array $values = [], bool $check_permissions = false): int
+    {
+        return self::entity('Group', $values, $check_permissions);
+    }
+
+    /**
+     * Create tag
+     *
+     * @param array $values Tag data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return int Tag ID
+     * @throws \Civi\RcBase\Exception\APIException
+     */
+    public static function tag(array $values = [], bool $check_permissions = false): int
+    {
+        return self::entity('Tag', $values, $check_permissions);
+    }
+
+    /**
+     * Add option
+     *
+     * @param string $option_group Name of option group
+     * @param array $values Option data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return string|null Value of option
+     * @throws \API_Exception
+     * @throws \Civi\API\Exception\UnauthorizedException
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public static function optionValue(string $option_group, array $values = [], bool $check_permissions = false): ?string
+    {
+        if (empty($option_group)) {
+            throw new MissingArgumentException('option group name');
+        }
+
+        $values['option_group_id.name'] = $option_group;
+        $option_value_id = self::entity('OptionValue', $values, $check_permissions);
+        $result = OptionValue::get($check_permissions)
+            ->addSelect('value')
+            ->addWhere('id', '=', $option_value_id)
+            ->execute();
+
+        return CRM_RcBase_Api_Get::parseResultsFirst($result, 'value');
+    }
+}

--- a/Civi/RcBase/ApiWrapper/Update.php
+++ b/Civi/RcBase/ApiWrapper/Update.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Civi\RcBase\ApiWrapper;
+
+use Civi\RcBase\Exception\APIException;
+use Civi\RcBase\Exception\InvalidArgumentException;
+use Civi\RcBase\Exception\MissingArgumentException;
+use Throwable;
+
+/**
+ * Common Update Actions
+ * Wrapper around APIv4
+ *
+ * @package  rc-base
+ * @author   Sandor Semsey <sandor@es-progress.hu>
+ * @license  AGPL-3.0
+ */
+class Update
+{
+    /**
+     * Update generic entity
+     *
+     * @param string $entity Name of entity
+     * @param int $entity_id Entity ID
+     * @param array $values Entity data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return array Updated entity data
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public static function entity(string $entity, int $entity_id, array $values = [], bool $check_permissions = false): array
+    {
+        if ($entity_id < 1) {
+            throw new InvalidArgumentException('entity ID', 'ID must be positive');
+        }
+        if (empty($values)) {
+            throw new MissingArgumentException('values', 'must contain at least one parameter');
+        }
+
+        try {
+            $results = civicrm_api4(
+                $entity,
+                'update',
+                [
+                    'where' => [
+                        ['id', '=', $entity_id],
+                    ],
+                    'values' => $values,
+                    'limit' => 1,
+                    'checkPermissions' => $check_permissions,
+                ]
+            );
+        } catch (Throwable $ex) {
+            throw new APIException($entity, 'update', $ex->getMessage());
+        }
+
+        if (count($results) < 1) {
+            throw new APIException($entity, 'update', 'Failed to update entity');
+        }
+
+        return $results->first() ?? [];
+    }
+
+    /**
+     * Update contact
+     *
+     * @param int $contact_id Contact ID
+     * @param array $values Contact data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return array Updated Contact data
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public static function contact(int $contact_id, array $values = [], bool $check_permissions = false): array
+    {
+        return self::entity('Contact', $contact_id, $values, $check_permissions);
+    }
+
+    /**
+     * Update email
+     *
+     * @param int $email_id Email ID
+     * @param array $values Email data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return array Updated Email data
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public static function email(int $email_id, array $values = [], bool $check_permissions = false): array
+    {
+        return self::entity('Email', $email_id, $values, $check_permissions);
+    }
+
+    /**
+     * Update phone
+     *
+     * @param int $phone_id Phone ID
+     * @param array $values Phone data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return array Updated Phone data
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public static function phone(int $phone_id, array $values = [], bool $check_permissions = false): array
+    {
+        return self::entity('Phone', $phone_id, $values, $check_permissions);
+    }
+
+    /**
+     * Update address
+     *
+     * @param int $address_id Address ID
+     * @param array $values Address data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return array Updated Address data
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public static function address(int $address_id, array $values = [], bool $check_permissions = false): array
+    {
+        return self::entity('Address', $address_id, $values, $check_permissions);
+    }
+
+    /**
+     * Update relationship
+     *
+     * @param int $relationship_id Relationship ID
+     * @param array $values Relationship data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return array Updated Relationship data
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public static function relationship(int $relationship_id, array $values = [], bool $check_permissions = false): array
+    {
+        return self::entity('Relationship', $relationship_id, $values, $check_permissions);
+    }
+
+    /**
+     * Update activity
+     *
+     * @param int $activity_id Activity ID
+     * @param array $values Activity data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return array Updated Activity data
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public static function activity(int $activity_id, array $values = [], bool $check_permissions = false): array
+    {
+        return self::entity('Activity', $activity_id, $values, $check_permissions);
+    }
+
+    /**
+     * Update group
+     *
+     * @param int $group_id Group ID
+     * @param array $values Group data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return array Updated Group data
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public static function group(int $group_id, array $values = [], bool $check_permissions = false): array
+    {
+        return self::entity('Group', $group_id, $values, $check_permissions);
+    }
+
+    /**
+     * Update tag
+     *
+     * @param int $tag_id Tag ID
+     * @param array $values Tag data
+     * @param bool $check_permissions Should we check permissions (ACLs)?
+     *
+     * @return array Updated Tag data
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public static function tag(int $tag_id, array $values = [], bool $check_permissions = false): array
+    {
+        return self::entity('Tag', $tag_id, $values, $check_permissions);
+    }
+}

--- a/Civi/RcBase/Utils/PHPUnit.php
+++ b/Civi/RcBase/Utils/PHPUnit.php
@@ -7,9 +7,27 @@ use CRM_RcBase_Api_Create;
 
 /**
  * Utilities for unit-testing
+ * Please don't use in production code!
  */
 class PHPUnit
 {
+    /**
+     * Static counter
+     *
+     * @var int
+     */
+    public static int $counter = 1;
+
+    /**
+     * Supply a monotonic incremented counter
+     *
+     * @return int
+     */
+    public static function nextCounter(): int
+    {
+        return self::$counter++;
+    }
+
     /**
      * Simulate a logged in system user
      *

--- a/Civi/RcBase/Utils/PHPUnit.php
+++ b/Civi/RcBase/Utils/PHPUnit.php
@@ -77,9 +77,7 @@ class PHPUnit
         $default = [
             'contact_type' => 'Individual',
             'first_name' => "user_{$counter}",
-            'middle_name' => 'middle',
-            'last_name' => 'Test',
-            'external_identifier' => $counter,
+            'external_identifier' => "ext_{$counter}",
         ];
 
         return CRM_RcBase_Api_Create::contact(array_merge($default, $extra));

--- a/info.xml
+++ b/info.xml
@@ -15,7 +15,7 @@
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
     <releaseDate>2022-10-22</releaseDate>
-    <version>1.14.0</version>
+    <version>1.15.0</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/tests/phpunit/Civi/RcBase/ApiWrapper/CreateTest.php
+++ b/tests/phpunit/Civi/RcBase/ApiWrapper/CreateTest.php
@@ -1,0 +1,344 @@
+<?php
+
+namespace Civi\RcBase\ApiWrapper;
+
+use Civi\Api4\Contact;
+use Civi\RcBase\Exception\APIException;
+use Civi\RcBase\Exception\InvalidArgumentException;
+use Civi\RcBase\Exception\MissingArgumentException;
+use Civi\RcBase\Utils\PHPUnit;
+use CRM_RcBase_HeadlessTestCase;
+
+/**
+ * Test API Create class
+ *
+ * @group headless
+ */
+class CreateTest extends CRM_RcBase_HeadlessTestCase
+{
+    /**
+     * @return void
+     * @throws \API_Exception
+     * @throws \Civi\API\Exception\UnauthorizedException
+     * @throws \Civi\RcBase\Exception\APIException
+     */
+    public function testCreateEntity()
+    {
+        $counter = PHPUnit::nextCounter();
+        $values = [
+            'contact_type' => 'Individual',
+            'first_name' => 'user_'.$counter,
+        ];
+
+        // Check contact not exists beforehand
+        $result = Contact::get()
+            ->addSelect('id')
+            ->addWhere('first_name', '=', $values['first_name'])
+            ->execute();
+        self::assertCount(0, $result, 'Contact should not be present');
+
+        $contact_id = Create::entity('Contact', $values);
+
+        // Check contact is present now and check ID also
+        $result = Contact::get()
+            ->addSelect('id')
+            ->addWhere('first_name', '=', $values['first_name'])
+            ->execute();
+        self::assertCount(1, $result, 'Failed to locate contact');
+        self::assertArrayHasKey('id', $result->first(), 'Id not returned');
+        self::assertSame($result->first()['id'], $contact_id, 'Wrong contact ID returned');
+    }
+
+    /**
+     * @return void
+     * @throws \Civi\RcBase\Exception\APIException
+     */
+    public function testMissingRequiredFieldThrowsApiException()
+    {
+        self::expectException(APIException::class);
+        self::expectExceptionMessage('Mandatory values missing');
+        Create::entity('Activity', [
+            'subject' => 'test subject',
+        ]);
+    }
+
+    /**
+     * @return void
+     * @throws \API_Exception
+     * @throws \Civi\API\Exception\UnauthorizedException
+     * @throws \Civi\RcBase\Exception\APIException
+     */
+    public function testCreateContactWithExtraUnknownFields()
+    {
+        $counter = PHPUnit::nextCounter();
+        $values = [
+            'contact_type' => 'Individual',
+            'first_name' => 'user_'.$counter,
+            'nonexistent_field_string' => 'Ides of March',
+            'nonexistent_field_int' => 15,
+            'nonexistent_field_bool' => true,
+        ];
+
+        $contact_id = Create::entity('Contact', $values);
+
+        $contacts = Contact::get()
+            ->addSelect('id')
+            ->addWhere('first_name', '=', $values['first_name'])
+            ->execute();
+        self::assertCount(1, $contacts, 'Failed to locate contact');
+        self::assertArrayHasKey('id', $contacts->first(), 'Id not returned');
+        self::assertSame($contacts->first()['id'], $contact_id, 'Wrong contact ID returned');
+    }
+
+    /**
+     * @return void
+     * @throws \Civi\RcBase\Exception\APIException
+     */
+    public function testCreateContactWithDuplicateExternalIdThrowsException()
+    {
+        $counter = PHPUnit::nextCounter();
+        $values = [
+            'contact_type' => 'Individual',
+            'external_identifier' => 'ext_'.$counter,
+        ];
+        Create::entity('Contact', $values);
+
+        // Create same contact
+        self::expectException(APIException::class);
+        self::expectExceptionMessage('DB Error: already exists');
+        Create::entity('Contact', $values);
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     */
+    public function testCreateEmail()
+    {
+        $values = [
+            'email' => 'ceasar@senate.rome',
+            'location_type_id' => 1,
+        ];
+        $contact_id = PHPUnit::createIndividual(PHPUnit::nextCounter());
+
+        self::assertNotNull(Create::email($contact_id, $values), 'Valid ID needs to be returned');
+
+        // Check invalid ID
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('contact ID');
+        Create::email(0, $values);
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     */
+    public function testCreatePhone()
+    {
+        $values = [
+            'phone' => '+12343243',
+            'location_type_id' => 1,
+        ];
+        $contact_id = PHPUnit::createIndividual(PHPUnit::nextCounter());
+
+        self::assertNotNull(Create::phone($contact_id, $values), 'Valid ID needs to be returned');
+
+        // Check invalid ID
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('contact ID');
+        Create::phone(0, $values);
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     */
+    public function testCreateAddress()
+    {
+        $values = [
+            'city' => 'Rome',
+            'location_type_id' => 1,
+        ];
+        $contact_id = PHPUnit::createIndividual(PHPUnit::nextCounter());
+
+        self::assertNotNull(Create::address($contact_id, $values), 'Valid ID needs to be returned');
+
+        // Check invalid ID
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('contact ID');
+        Create::address(0, $values);
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     */
+    public function testCreateRelationship()
+    {
+        $contact_id_other = PHPUnit::createIndividual(PHPUnit::nextCounter());
+        $values = [
+            'contact_id_b' => $contact_id_other,
+            'relationship_type_id' => 1,
+            'description' => 'Test',
+        ];
+        $contact_id = PHPUnit::createIndividual(PHPUnit::nextCounter());
+
+        self::assertNotNull(Create::relationship($contact_id, $values), 'Valid ID needs to be returned');
+
+        // Check invalid ID
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('contact ID');
+        Create::relationship(0, $values);
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     */
+    public function testCreateContribution()
+    {
+        $values = [
+            'financial_type_id' => 1,
+            'total_amount' => 13.43,
+            'trxn_id' => '12345',
+        ];
+        $contact_id = PHPUnit::createIndividual(PHPUnit::nextCounter());
+
+        self::assertNotNull(Create::contribution($contact_id, $values), 'Valid ID needs to be returned');
+
+        // Check invalid ID
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('contact ID');
+        Create::contribution(0, $values);
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     */
+    public function testCreateContributionWithDuplicateTransactionIdThrowsException()
+    {
+        $values = [
+            'financial_type_id' => 1,
+            'total_amount' => 13.43,
+            'trxn_id' => 'duplicate',
+        ];
+        $contact_id = PHPUnit::createIndividual(PHPUnit::nextCounter());
+
+        self::assertNotNull(Create::contribution($contact_id, $values), 'Valid ID needs to be returned');
+
+        // Create same contribution
+        self::expectException(APIException::class);
+        self::expectExceptionMessage('Duplicate error');
+        Create::contribution($contact_id, $values);
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     */
+    public function testCreateActivity()
+    {
+        $contact_id_source = PHPUnit::createIndividual(PHPUnit::nextCounter());
+        $values = [
+            'source_contact_id' => $contact_id_source,
+            'activity_type_id' => 1,
+            'subject' => 'Tribute',
+        ];
+        $contact_id = PHPUnit::createIndividual(PHPUnit::nextCounter());
+
+        self::assertNotNull(Create::activity($contact_id, $values), 'Valid ID needs to be returned');
+
+        // Check invalid ID
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('contact ID');
+        Create::activity(0, $values);
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     */
+    public function testTagContact()
+    {
+        $values = [
+            'name' => 'Test tag',
+        ];
+        $tag_id = Create::entity('Tag', $values);
+        $contact_id = PHPUnit::createIndividual(PHPUnit::nextCounter());
+
+        self::assertNotNull(Create::tagContact($contact_id, $tag_id), 'Valid ID needs to be returned');
+
+        // Check invalid ID
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('tag ID');
+        Create::tagContact($contact_id, 0);
+    }
+
+    /**
+     * @return void
+     * @throws \Civi\RcBase\Exception\APIException
+     */
+    public function testCreateGroup()
+    {
+        $values = [
+            'title' => 'Placeholder group',
+            'name' => 'place_holder_group',
+            'description' => 'This is some description',
+        ];
+        self::assertNotNull(Create::group($values), 'Valid ID needs to be returned');
+    }
+
+    /**
+     * @return void
+     * @throws \Civi\RcBase\Exception\APIException
+     */
+    public function testCreateTag()
+    {
+        $values = [
+            'name' => 'test_tag',
+            'description' => 'This is a test tag',
+            'is_reserved' => true,
+            'is_selectable' => false,
+        ];
+        self::assertNotNull(Create::tag($values), 'Valid ID needs to be returned');
+    }
+
+    /**
+     * @return void
+     * @throws \API_Exception
+     * @throws \Civi\API\Exception\UnauthorizedException
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public function testCreateOptionValue()
+    {
+        $values = [
+            'label' => 'new_status',
+            'name' => 'new_status',
+            'value' => 'new_state',
+        ];
+        self::assertNotNull(Create::optionValue('contribution_status', $values), 'Valid ID needs to be returned');
+
+        // Check empty option group
+        self::expectException(MissingArgumentException::class);
+        self::expectExceptionMessage('option group name');
+        Create::optionValue('', $values);
+    }
+}

--- a/tests/phpunit/Civi/RcBase/ApiWrapper/UpdateTest.php
+++ b/tests/phpunit/Civi/RcBase/ApiWrapper/UpdateTest.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace Civi\RcBase\ApiWrapper;
+
+use Civi\Api4\Contact;
+use Civi\RcBase\Exception\APIException;
+use Civi\RcBase\Exception\InvalidArgumentException;
+use Civi\RcBase\Exception\MissingArgumentException;
+use Civi\RcBase\Utils\PHPUnit;
+use CRM_RcBase_Api_Get;
+use CRM_RcBase_HeadlessTestCase;
+
+/**
+ * Test API Update class
+ *
+ * @group headless
+ */
+class UpdateTest extends CRM_RcBase_HeadlessTestCase
+{
+    /**
+     * @return void
+     * @throws \API_Exception
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\API\Exception\UnauthorizedException
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public function testUpdateContact()
+    {
+        // Create contact
+        $params = [
+            'first_name' => 'narcos',
+            'last_name' => 'Crassus',
+            'job_title' => 'consul',
+        ];
+        $contact_id = PHPUnit::createIndividual(PHPUnit::nextCounter(), $params);
+        $data_old = CRM_RcBase_Api_Get::contactData($contact_id);
+
+        // Change data & update
+        $params = [
+            // Change value
+            'first_name' => 'Marcus',
+            // Add new field
+            'middle_name' => 'Licinius',
+            // Keep value
+            'last_name' => 'Crassus',
+            // Delete fields
+            'job_title' => null,
+        ];
+        Update::contact($contact_id, $params);
+        $data_new = CRM_RcBase_Api_Get::contactData($contact_id);
+
+        // Check if data changed
+        self::assertNotSame($data_old, $data_new, 'Data not changed.');
+
+        // Check new data
+        $result = Contact::get()
+            ->addSelect('first_name', 'middle_name', 'last_name', 'job_title')
+            ->addWhere('id', '=', $contact_id)
+            ->setLimit(1)
+            ->execute();
+        unset($result[0]['id']);
+        self::assertSame($result[0], $params, 'Bad updated contact data.');
+    }
+
+    /**
+     * @return void
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public function testUpdateInvalidEntityIdThrowsException()
+    {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('ID must be positive');
+        Update::entity('Contact', -5, []);
+    }
+
+    /**
+     * @return void
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public function testUpdateEmptyValuesThrowsException()
+    {
+        self::expectException(MissingArgumentException::class);
+        self::expectExceptionMessage('must contain at least one parameter');
+        Update::entity('Contact', 5, []);
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public function testUpdateContactInvalidFieldValueTypeThrowsException()
+    {
+        $contact_id = PHPUnit::createIndividual(PHPUnit::nextCounter());
+
+        self::expectException(APIException::class);
+        self::expectExceptionMessage('DB Error: syntax error');
+        Update::contact($contact_id, ['contact_type' => 'Invalid contact type',]);
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public function testUpdateEmail()
+    {
+        $contact_id = PHPUnit::createIndividual(PHPUnit::nextCounter());
+        $values = [
+            'email' => 'ceasar@senate.rome',
+            'location_type_id' => 1,
+        ];
+        $id = Create::email($contact_id, $values);
+
+        // Change data & update
+        $values['email'] = 'julius@senate.rome';
+        $values['location_type_id'] = 2;
+        self::assertNotEmpty(Update::email($id, $values), 'Empty data returned');
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public function testUpdatePhone()
+    {
+        $contact_id = PHPUnit::createIndividual(PHPUnit::nextCounter());
+        $values = [
+            'phone' => '+1234',
+            'location_type_id' => 1,
+        ];
+        $id = Create::phone($contact_id, $values);
+
+        // Change data & update
+        $values['phone'] = '+98765';
+        self::assertNotEmpty(Update::phone($id, $values), 'Empty data returned');
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public function testUpdateAddress()
+    {
+        $contact_id = PHPUnit::createIndividual(PHPUnit::nextCounter());
+        $values = [
+            'city' => 'Rome',
+            'location_type_id' => 1,
+        ];
+        $id = Create::address($contact_id, $values);
+
+        // Change data & update
+        $values['city'] = 'Alexandria';
+        self::assertNotEmpty(Update::address($id, $values), 'Empty data returned');
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public function testUpdateRelationship()
+    {
+        $contact_id = PHPUnit::createIndividual(PHPUnit::nextCounter());
+        $contact_id_other = PHPUnit::createIndividual(PHPUnit::nextCounter());
+        $contact_id_other_new = PHPUnit::createIndividual(PHPUnit::nextCounter());
+        $values = [
+            'contact_id_b' => $contact_id_other,
+            'relationship_type_id' => 1,
+            'description' => 'Test',
+        ];
+        $id = Create::relationship($contact_id, $values);
+
+        // Change data & update
+        $values['contact_id_b'] = $contact_id_other_new;
+        self::assertNotEmpty(Update::relationship($id, $values), 'Empty data returned');
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public function testUpdateActivity()
+    {
+        $contact_id = PHPUnit::createIndividual(PHPUnit::nextCounter());
+        $contact_id_source = PHPUnit::createIndividual(PHPUnit::nextCounter());
+        $values = [
+            'source_contact_id' => $contact_id_source,
+            'activity_type_id' => 1,
+            'subject' => 'Test',
+        ];
+        $id = Create::activity($contact_id, $values);
+
+        // Change data & update
+        $values['activity_type_id'] = 2;
+        self::assertNotEmpty(Update::activity($id, $values), 'Empty data returned');
+    }
+
+    /**
+     * @return void
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public function testUpdateGroup()
+    {
+        $values = [
+            'title' => 'test group',
+            'name' => 'test_group',
+            'description' => 'This is some description',
+            'is_active' => true,
+            'is_reserved' => true,
+        ];
+        $id = Create::group($values);
+
+        // Change data & update
+        $values['title'] = 'Other title';
+        $values['is_reserved'] = false;
+        self::assertNotEmpty(Update::group($id, $values), 'Empty data returned');
+    }
+
+    /**
+     * @return void
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public function testUpdateTag()
+    {
+        $values = [
+            'name' => 'test_tag',
+            'description' => 'This is a test tag',
+            'is_reserved' => true,
+            'is_selectable' => false,
+        ];
+        $id = Create::tag($values);
+
+        // Change data & update
+        $values['is_reserved'] = false;
+        $values['is_selectable'] = true;
+        self::assertNotEmpty(Update::tag($id, $values), 'Empty data returned');
+    }
+}

--- a/tests/phpunit/Civi/RcBase/Utils/PHPUnitTest.php
+++ b/tests/phpunit/Civi/RcBase/Utils/PHPUnitTest.php
@@ -14,6 +14,15 @@ class PHPUnitTest extends CRM_RcBase_HeadlessTestCase
 {
     /**
      * @return void
+     */
+    public function testCounter()
+    {
+        $counter = PHPUnit::nextCounter();
+        self::assertSame($counter + 1, PHPUnit::nextCounter(), 'Counter not incremented');
+    }
+
+    /**
+     * @return void
      * @throws \CRM_Core_Exception
      * @throws \CiviCRM_API3_Exception
      */


### PR DESCRIPTION
also reimplement unit-tests.

The new classes act as a drop-in class for the old ones. Public interface not changed.