### PR TITLE
Standardize tests

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -17,8 +17,8 @@
         <url desc="Support">https://github.com/reflexive-communications/rc-base/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2023-03-09</releaseDate>
-    <version>1.34.0</version>
+    <releaseDate>2023-03-16</releaseDate>
+    <version>1.35.0</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/tests/phpunit/CRM/RcBase/Api/ApiTestCase.php
+++ b/tests/phpunit/CRM/RcBase/Api/ApiTestCase.php
@@ -1,10 +1,12 @@
 <?php
 
+use Civi\RcBase\HeadlessTestCase;
+
 /**
  * Base test class for API headless tests
  * Contains helper functions for testing
  */
-class CRM_RcBase_Api_ApiTestCase extends CRM_RcBase_HeadlessTestCase
+class CRM_RcBase_Api_ApiTestCase extends HeadlessTestCase
 {
     /**
      * External ID counter

--- a/tests/phpunit/CRM/RcBase/Api/ApiTestCase.php
+++ b/tests/phpunit/CRM/RcBase/Api/ApiTestCase.php
@@ -3,8 +3,7 @@
 use Civi\RcBase\HeadlessTestCase;
 
 /**
- * Base test class for API headless tests
- * Contains helper functions for testing
+ * @group headless
  */
 class CRM_RcBase_Api_ApiTestCase extends HeadlessTestCase
 {

--- a/tests/phpunit/CRM/RcBase/Api/CreateTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/CreateTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * Test API Create class
- *
  * @group headless
  */
 class CRM_RcBase_Api_CreateTest extends CRM_RcBase_Api_ApiTestCase

--- a/tests/phpunit/CRM/RcBase/Api/CreateTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/CreateTest.php
@@ -5,7 +5,7 @@
  *
  * @group headless
  */
-class CRM_RcBase_Api_CreateHeadlessTest extends CRM_RcBase_Api_ApiTestCase
+class CRM_RcBase_Api_CreateTest extends CRM_RcBase_Api_ApiTestCase
 {
     /**
      * @throws CRM_Core_Exception

--- a/tests/phpunit/CRM/RcBase/Api/GetTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/GetTest.php
@@ -6,8 +6,6 @@ use Civi\RcBase\ApiWrapper\Create;
 use Civi\RcBase\Utils\PHPUnit;
 
 /**
- * Test API Get class
- *
  * @group headless
  */
 class CRM_RcBase_Api_GetTest extends CRM_RcBase_Api_ApiTestCase

--- a/tests/phpunit/CRM/RcBase/Api/GetTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/GetTest.php
@@ -10,7 +10,7 @@ use Civi\RcBase\Utils\PHPUnit;
  *
  * @group headless
  */
-class CRM_RcBase_Api_GetHeadlessTest extends CRM_RcBase_Api_ApiTestCase
+class CRM_RcBase_Api_GetTest extends CRM_RcBase_Api_ApiTestCase
 {
     /**
      * @throws UnauthorizedException

--- a/tests/phpunit/CRM/RcBase/Api/RemoveTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/RemoveTest.php
@@ -3,8 +3,6 @@
 use Civi\Api4\GroupContact;
 
 /**
- * Test API Remove class
- *
  * @group headless
  */
 class CRM_RcBase_Api_RemoveTest extends CRM_RcBase_Api_ApiTestCase

--- a/tests/phpunit/CRM/RcBase/Api/RemoveTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/RemoveTest.php
@@ -7,7 +7,7 @@ use Civi\Api4\GroupContact;
  *
  * @group headless
  */
-class CRM_RcBase_Api_RemoveHeadlessTest extends CRM_RcBase_Api_ApiTestCase
+class CRM_RcBase_Api_RemoveTest extends CRM_RcBase_Api_ApiTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/CRM/RcBase/Api/SaveTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/SaveTest.php
@@ -3,8 +3,6 @@
 use Civi\Api4\GroupContact;
 
 /**
- * Test API Save class
- *
  * @group headless
  */
 class CRM_RcBase_Api_SaveTest extends CRM_RcBase_Api_ApiTestCase

--- a/tests/phpunit/CRM/RcBase/Api/SaveTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/SaveTest.php
@@ -7,7 +7,7 @@ use Civi\Api4\GroupContact;
  *
  * @group headless
  */
-class CRM_RcBase_Api_SaveHeadlessTest extends CRM_RcBase_Api_ApiTestCase
+class CRM_RcBase_Api_SaveTest extends CRM_RcBase_Api_ApiTestCase
 {
     /**
      * @throws \API_Exception

--- a/tests/phpunit/CRM/RcBase/Api/UpdateTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/UpdateTest.php
@@ -5,7 +5,7 @@
  *
  * @group headless
  */
-class CRM_RcBase_Api_UpdateHeadlessTest extends CRM_RcBase_Api_ApiTestCase
+class CRM_RcBase_Api_UpdateTest extends CRM_RcBase_Api_ApiTestCase
 {
     /**
      * @throws CRM_Core_Exception

--- a/tests/phpunit/CRM/RcBase/Api/UpdateTest.php
+++ b/tests/phpunit/CRM/RcBase/Api/UpdateTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * Test API Update class
- *
  * @group headless
  */
 class CRM_RcBase_Api_UpdateTest extends CRM_RcBase_Api_ApiTestCase

--- a/tests/phpunit/CRM/RcBase/ConfigHeadlessTest.php
+++ b/tests/phpunit/CRM/RcBase/ConfigHeadlessTest.php
@@ -1,11 +1,5 @@
 <?php
 
-use CRM_RcBase_ExtensionUtil as E;
-use Civi\Test;
-use Civi\Test\HeadlessInterface;
-use Civi\Test\HookInterface;
-use Civi\Test\TransactionalInterface;
-
 const DEFAULT_CONFIGURATION = [
     "Key1" => "value1",
     "Key2" => 12,
@@ -30,50 +24,8 @@ class TestConfig extends CRM_RcBase_Config
  *
  * @group headless
  */
-class CRM_RcBase_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface
+class CRM_RcBase_ConfigHeadlessTest extends CRM_RcBase_HeadlessTestCase
 {
-    public function setUpHeadless()
-    {
-        return Test::headless()
-            ->installMe(__DIR__)
-            ->apply();
-    }
-
-    /**
-     * Create a clean DB before running tests
-     *
-     * @throws CRM_Extension_Exception_ParseException
-     */
-    public static function setUpBeforeClass(): void
-    {
-        Test::headless()
-            ->installMe(__DIR__)
-            ->apply(true);
-    }
-
-    /**
-     * Create a clean DB before running tests
-     *
-     * @throws CRM_Extension_Exception_ParseException
-     */
-    public static function tearDownAfterClass(): void
-    {
-        Test::headless()
-            ->uninstallMe(__DIR__)
-            ->apply(true);
-    }
-
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    public function tearDown(): void
-    {
-        $this->getConfig()->remove();
-        parent::tearDown();
-    }
-
     private function getConfig()
     {
         return new TestConfig(CONFIG_NAME);
@@ -165,17 +117,6 @@ class CRM_RcBase_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implemen
         $cfg["brand-new-key"] = false;
         self::assertTrue($config->update($cfg), "Update config has to be successful.");
         self::assertSame($cfg, $config->get(), "Invalid updated configuration.");
-    }
-
-    /**
-     * It checks that the get function works well.
-     */
-    public function testLoadEmptyConfig()
-    {
-        $config = $this->getConfig();
-        self::expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        self::expectExceptionMessage(CONFIG_NAME."_config config invalid.", "Invalid exception message.");
-        self::assertEmpty($config->load(), "Load result supposed to be empty.");
     }
 
     public function testLoadCreatedConfig()

--- a/tests/phpunit/CRM/RcBase/ConfigTest.php
+++ b/tests/phpunit/CRM/RcBase/ConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\RcBase\HeadlessTestCase;
+
 const DEFAULT_CONFIGURATION = [
     "Key1" => "value1",
     "Key2" => 12,
@@ -24,7 +26,7 @@ class TestConfig extends CRM_RcBase_Config
  *
  * @group headless
  */
-class CRM_RcBase_ConfigTest extends CRM_RcBase_HeadlessTestCase
+class CRM_RcBase_ConfigTest extends HeadlessTestCase
 {
     private function getConfig()
     {

--- a/tests/phpunit/CRM/RcBase/ConfigTest.php
+++ b/tests/phpunit/CRM/RcBase/ConfigTest.php
@@ -3,13 +3,13 @@
 use Civi\RcBase\HeadlessTestCase;
 
 const DEFAULT_CONFIGURATION = [
-    "Key1" => "value1",
-    "Key2" => 12,
-    "Key3" => true,
-    "Key4" => [],
-    "Key5" => ["SubKey" => "Great success!"],
+    'Key1' => 'value1',
+    'Key2' => 12,
+    'Key3' => true,
+    'Key4' => [],
+    'Key5' => ['SubKey' => 'Great success!'],
 ];
-const CONFIG_NAME = "rcBase_test";
+const CONFIG_NAME = 'rcBase_test';
 
 class TestConfig extends CRM_RcBase_Config
 {
@@ -35,37 +35,37 @@ class CRM_RcBase_ConfigTest extends HeadlessTestCase
     public function testCreate()
     {
         $config = $this->getConfig();
-        self::assertTrue($config->create(), "Create config has to be successful.");
+        self::assertTrue($config->create(), 'Create config has to be successful.');
         $cfg = $config->get();
-        self::assertSame(DEFAULT_CONFIGURATION, $cfg, "Invalid configuration has been returned.");
-        self::assertTrue($config->create(), "Create config has to be successful multiple times.");
+        self::assertSame(DEFAULT_CONFIGURATION, $cfg, 'Invalid configuration has been returned.');
+        self::assertTrue($config->create(), 'Create config has to be successful multiple times.');
     }
 
     public function testCreateAfterChanges()
     {
         $config = $this->getConfig();
-        self::assertTrue($config->create(), "Create config has to be successful.");
+        self::assertTrue($config->create(), 'Create config has to be successful.');
         $cfg = $config->get();
-        self::assertSame(DEFAULT_CONFIGURATION, $cfg, "Invalid configuration has been returned.");
-        self::assertTrue($config->create(), "Create config has to be successful multiple times.");
+        self::assertSame(DEFAULT_CONFIGURATION, $cfg, 'Invalid configuration has been returned.');
+        self::assertTrue($config->create(), 'Create config has to be successful multiple times.');
         // Update config and call create. The updated config has to be created.
         foreach ($cfg as $k => $v) {
-            $newKey = $k."new";
+            $newKey = $k.'new';
             unset($cfg[$k]);
             $cfg[$newKey] = $v;
-            $cfg[$newKey."v2"] = false;
+            $cfg[$newKey.'v2'] = false;
             break;
         }
-        self::assertTrue($config->update($cfg), "Update config has to be successful.");
-        self::assertEmpty($config->load(), "Load result supposed to be empty.");
-        self::assertTrue($config->create(), "Create config has to be successful with changed config.");
+        self::assertTrue($config->update($cfg), 'Update config has to be successful.');
+        self::assertEmpty($config->load(), 'Load result supposed to be empty.');
+        self::assertTrue($config->create(), 'Create config has to be successful with changed config.');
         $cfgNew = $config->get();
-        self::assertSame($cfg, $cfgNew, "Invalid configuration has been returned.");
+        self::assertSame($cfg, $cfgNew, 'Invalid configuration has been returned.');
         // reset the changes with creating the db with a new config instance.
         $otherConfig = $this->getConfig();
-        self::assertTrue($otherConfig->create(), "Create config has to be successful.");
+        self::assertTrue($otherConfig->create(), 'Create config has to be successful.');
         $otherCfg = $otherConfig->get();
-        self::assertSame(DEFAULT_CONFIGURATION, $otherCfg, "Invalid configuration has been returned.");
+        self::assertSame(DEFAULT_CONFIGURATION, $otherCfg, 'Invalid configuration has been returned.');
     }
 
     /**
@@ -76,7 +76,7 @@ class CRM_RcBase_ConfigTest extends HeadlessTestCase
         $config = $this->getConfig();
         // preset the config.
         Civi::settings()->add([CONFIG_NAME => DEFAULT_CONFIGURATION]);
-        self::assertTrue($config->remove(), "Remove config has to be successful.");
+        self::assertTrue($config->remove(), 'Remove config has to be successful.');
     }
 
     /**
@@ -87,12 +87,12 @@ class CRM_RcBase_ConfigTest extends HeadlessTestCase
         $config = $this->getConfig();
         // preset the config.
         Civi::settings()->add([CONFIG_NAME => DEFAULT_CONFIGURATION]);
-        self::assertSame(DEFAULT_CONFIGURATION, $config->get(), "Invalid configuration has been returned.");
+        self::assertSame(DEFAULT_CONFIGURATION, $config->get(), 'Invalid configuration has been returned.');
 
         // remove the config
-        self::assertTrue($config->remove(), "Remove config has to be successful.");
-        self::expectException(CRM_Core_Exception::class, "Invalid exception class.");
-        self::expectExceptionMessage(CONFIG_NAME."_config config is missing.", "Invalid exception message.");
+        self::assertTrue($config->remove(), 'Remove config has to be successful.');
+        self::expectException(CRM_Core_Exception::class);
+        self::expectExceptionMessage(CONFIG_NAME.'_config config is missing.');
         $config->get();
     }
 
@@ -106,15 +106,15 @@ class CRM_RcBase_ConfigTest extends HeadlessTestCase
         Civi::settings()->add([CONFIG_NAME => DEFAULT_CONFIGURATION]);
         $cfg = Civi::settings()->get(CONFIG_NAME);
         foreach ($cfg as $k => $v) {
-            $newKey = $k."new";
+            $newKey = $k.'new';
             unset($cfg[$k]);
             $cfg[$newKey] = $v;
-            $cfg[$newKey."v2"] = false;
+            $cfg[$newKey.'v2'] = false;
             break;
         }
-        $cfg["brand-new-key"] = false;
-        self::assertTrue($config->update($cfg), "Update config has to be successful.");
-        self::assertSame($cfg, $config->get(), "Invalid updated configuration.");
+        $cfg['brand-new-key'] = false;
+        self::assertTrue($config->update($cfg), 'Update config has to be successful.');
+        self::assertSame($cfg, $config->get(), 'Invalid updated configuration.');
     }
 
     public function testLoadCreatedConfig()
@@ -122,13 +122,13 @@ class CRM_RcBase_ConfigTest extends HeadlessTestCase
         $config = $this->getConfig();
         // preset the config.
         $config->create();
-        self::assertEmpty($config->load(), "Load result supposed to be empty.");
+        self::assertEmpty($config->load(), 'Load result supposed to be empty.');
         $cfg = $config->get();
-        self::assertEquals(DEFAULT_CONFIGURATION, $cfg, "Invalid loaded configuration.");
+        self::assertEquals(DEFAULT_CONFIGURATION, $cfg, 'Invalid loaded configuration.');
         // update the config
-        $cfg["brand-new-key"] = false;
-        self::assertTrue($config->update($cfg), "Update config has to be successful.");
-        self::assertEmpty($config->load(), "Load result supposed to be empty.");
-        self::assertSame($cfg, $config->get(), "Invalid loaded configuration.");
+        $cfg['brand-new-key'] = false;
+        self::assertTrue($config->update($cfg), 'Update config has to be successful.');
+        self::assertEmpty($config->load(), 'Load result supposed to be empty.');
+        self::assertSame($cfg, $config->get(), 'Invalid loaded configuration.');
     }
 }

--- a/tests/phpunit/CRM/RcBase/ConfigTest.php
+++ b/tests/phpunit/CRM/RcBase/ConfigTest.php
@@ -20,10 +20,6 @@ class TestConfig extends CRM_RcBase_Config
 }
 
 /**
- * Config class test cases.
- * It tests the testConfig class that extends from the config and implements the
- * defaultConfiguration method.
- *
  * @group headless
  */
 class CRM_RcBase_ConfigTest extends HeadlessTestCase

--- a/tests/phpunit/CRM/RcBase/ConfigTest.php
+++ b/tests/phpunit/CRM/RcBase/ConfigTest.php
@@ -24,7 +24,7 @@ class TestConfig extends CRM_RcBase_Config
  *
  * @group headless
  */
-class CRM_RcBase_ConfigHeadlessTest extends CRM_RcBase_HeadlessTestCase
+class CRM_RcBase_ConfigTest extends CRM_RcBase_HeadlessTestCase
 {
     private function getConfig()
     {

--- a/tests/phpunit/CRM/RcBase/File/FileTest.php
+++ b/tests/phpunit/CRM/RcBase/File/FileTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use Civi\RcBase\HeadlessTestCase;
+
 /**
  * @group headless
  */
-class CRM_RcBase_File_FileTest extends CRM_RcBase_HeadlessTestCase
+class CRM_RcBase_File_FileTest extends HeadlessTestCase
 {
     public function provideFilesToCheck(): array
     {

--- a/tests/phpunit/CRM/RcBase/File/FileTest.php
+++ b/tests/phpunit/CRM/RcBase/File/FileTest.php
@@ -1,13 +1,9 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
 /**
- * Test CRM_RcBase_File
- *
- * @group unit
+ * @group headless
  */
-class CRM_RcBase_File_FileTest extends TestCase
+class CRM_RcBase_File_FileTest extends CRM_RcBase_HeadlessTestCase
 {
     public function provideFilesToCheck(): array
     {

--- a/tests/phpunit/CRM/RcBase/PermissionsTest.php
+++ b/tests/phpunit/CRM/RcBase/PermissionsTest.php
@@ -3,8 +3,6 @@
 use Civi\RcBase\HeadlessTestCase;
 
 /**
- * Test Permissions class
- *
  * @group headless
  */
 class CRM_RcBase_PermissionsTest extends HeadlessTestCase

--- a/tests/phpunit/CRM/RcBase/PermissionsTest.php
+++ b/tests/phpunit/CRM/RcBase/PermissionsTest.php
@@ -5,7 +5,7 @@
  *
  * @group headless
  */
-class CRM_RcBase_PermissionsHeadlessTest extends CRM_RcBase_HeadlessTestCase
+class CRM_RcBase_PermissionsTest extends CRM_RcBase_HeadlessTestCase
 {
     /**
      * Test custom permissions are available

--- a/tests/phpunit/CRM/RcBase/PermissionsTest.php
+++ b/tests/phpunit/CRM/RcBase/PermissionsTest.php
@@ -1,11 +1,13 @@
 <?php
 
+use Civi\RcBase\HeadlessTestCase;
+
 /**
  * Test Permissions class
  *
  * @group headless
  */
-class CRM_RcBase_PermissionsTest extends CRM_RcBase_HeadlessTestCase
+class CRM_RcBase_PermissionsTest extends HeadlessTestCase
 {
     /**
      * Test custom permissions are available

--- a/tests/phpunit/CRM/RcBase/Processor/BaseTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/BaseTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use Civi\RcBase\HeadlessTestCase;
+
 /**
  * @group headless
  */
-class CRM_RcBase_Processor_BaseTest extends CRM_RcBase_HeadlessTestCase
+class CRM_RcBase_Processor_BaseTest extends HeadlessTestCase
 {
     /**
      * Content types

--- a/tests/phpunit/CRM/RcBase/Processor/BaseTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/BaseTest.php
@@ -1,13 +1,9 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
 /**
- * Test Base Processor class
- *
- * @group unit
+ * @group headless
  */
-class CRM_RcBase_Processor_BaseTest extends TestCase
+class CRM_RcBase_Processor_BaseTest extends CRM_RcBase_HeadlessTestCase
 {
     /**
      * Content types

--- a/tests/phpunit/CRM/RcBase/Processor/ConfigTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/ConfigTest.php
@@ -1,13 +1,9 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
 /**
- * Test Config Processor class
- *
- * @group unit
+ * @group headless
  */
-class CRM_RcBase_Processor_ConfigTest extends TestCase
+class CRM_RcBase_Processor_ConfigTest extends CRM_RcBase_HeadlessTestCase
 {
     public function provideStrings()
     {

--- a/tests/phpunit/CRM/RcBase/Processor/ConfigTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/ConfigTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use Civi\RcBase\HeadlessTestCase;
+
 /**
  * @group headless
  */
-class CRM_RcBase_Processor_ConfigTest extends CRM_RcBase_HeadlessTestCase
+class CRM_RcBase_Processor_ConfigTest extends HeadlessTestCase
 {
     public function provideStrings()
     {

--- a/tests/phpunit/CRM/RcBase/Processor/JSONTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/JSONTest.php
@@ -1,13 +1,9 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
 /**
- * Test JSON Processor class
- *
- * @group unit
+ * @group headless
  */
-class CRM_RcBase_Processor_JSONTest extends TestCase
+class CRM_RcBase_Processor_JSONTest extends CRM_RcBase_HeadlessTestCase
 {
     /**
      * Provide valid JSON

--- a/tests/phpunit/CRM/RcBase/Processor/JSONTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/JSONTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use Civi\RcBase\HeadlessTestCase;
+
 /**
  * @group headless
  */
-class CRM_RcBase_Processor_JSONTest extends CRM_RcBase_HeadlessTestCase
+class CRM_RcBase_Processor_JSONTest extends HeadlessTestCase
 {
     /**
      * Provide valid JSON

--- a/tests/phpunit/CRM/RcBase/Processor/UrlEncodedFormTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/UrlEncodedFormTest.php
@@ -1,13 +1,9 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
 /**
- * Test URL encoded form Processor class
- *
- * @group unit
+ * @group headless
  */
-class CRM_RcBase_Processor_UrlEncodedFormTest extends TestCase
+class CRM_RcBase_Processor_UrlEncodedFormTest extends CRM_RcBase_HeadlessTestCase
 {
     public function testParseGet()
     {

--- a/tests/phpunit/CRM/RcBase/Processor/UrlEncodedFormTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/UrlEncodedFormTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use Civi\RcBase\HeadlessTestCase;
+
 /**
  * @group headless
  */
-class CRM_RcBase_Processor_UrlEncodedFormTest extends CRM_RcBase_HeadlessTestCase
+class CRM_RcBase_Processor_UrlEncodedFormTest extends HeadlessTestCase
 {
     public function testParseGet()
     {

--- a/tests/phpunit/CRM/RcBase/Processor/XMLTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/XMLTest.php
@@ -1,13 +1,9 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
 /**
- * Test XML Processor class
- *
- * @group unit
+ * @group headless
  */
-class CRM_RcBase_Processor_XMLTest extends TestCase
+class CRM_RcBase_Processor_XMLTest extends CRM_RcBase_HeadlessTestCase
 {
     /**
      * @throws \CRM_Core_Exception

--- a/tests/phpunit/CRM/RcBase/Processor/XMLTest.php
+++ b/tests/phpunit/CRM/RcBase/Processor/XMLTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use Civi\RcBase\HeadlessTestCase;
+
 /**
  * @group headless
  */
-class CRM_RcBase_Processor_XMLTest extends CRM_RcBase_HeadlessTestCase
+class CRM_RcBase_Processor_XMLTest extends HeadlessTestCase
 {
     /**
      * @throws \CRM_Core_Exception

--- a/tests/phpunit/CRM/RcBase/SettingTest.php
+++ b/tests/phpunit/CRM/RcBase/SettingTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use Civi\RcBase\HeadlessTestCase;
+
 /**
  * @group headless
  */
-class CRM_RcBase_SettingTest extends CRM_RcBase_HeadlessTestCase
+class CRM_RcBase_SettingTest extends HeadlessTestCase
 {
     /**
      * @return array

--- a/tests/phpunit/CRM/RcBase/Test/MockPhpStreamTest.php
+++ b/tests/phpunit/CRM/RcBase/Test/MockPhpStreamTest.php
@@ -1,13 +1,9 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
 /**
- * Test MockPhpStream Processor class
- *
- * @group unit
+ * @group headless
  */
-class CRM_RcBase_Test_MockPhpStreamTest extends TestCase
+class CRM_RcBase_Test_MockPhpStreamTest extends CRM_RcBase_HeadlessTestCase
 {
     /**
      * Provide streams for the php:// stream wrapper

--- a/tests/phpunit/CRM/RcBase/Test/MockPhpStreamTest.php
+++ b/tests/phpunit/CRM/RcBase/Test/MockPhpStreamTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use Civi\RcBase\HeadlessTestCase;
+
 /**
  * @group headless
  */
-class CRM_RcBase_Test_MockPhpStreamTest extends CRM_RcBase_HeadlessTestCase
+class CRM_RcBase_Test_MockPhpStreamTest extends HeadlessTestCase
 {
     /**
      * Provide streams for the php:// stream wrapper

--- a/tests/phpunit/CRM/RcBase/Test/UtilsTest.php
+++ b/tests/phpunit/CRM/RcBase/Test/UtilsTest.php
@@ -1,11 +1,13 @@
 <?php
 
+use Civi\RcBase\HeadlessTestCase;
+
 /**
  * Test Utils class
  *
  * @group headless
  */
-class CRM_RcBase_Test_UtilsTest extends CRM_RcBase_HeadlessTestCase
+class CRM_RcBase_Test_UtilsTest extends HeadlessTestCase
 {
     /**
      * @throws \API_Exception

--- a/tests/phpunit/CRM/RcBase/Test/UtilsTest.php
+++ b/tests/phpunit/CRM/RcBase/Test/UtilsTest.php
@@ -3,8 +3,6 @@
 use Civi\RcBase\HeadlessTestCase;
 
 /**
- * Test Utils class
- *
  * @group headless
  */
 class CRM_RcBase_Test_UtilsTest extends HeadlessTestCase

--- a/tests/phpunit/Civi/Api4/Action/Contact/AnonymizeTest.php
+++ b/tests/phpunit/Civi/Api4/Action/Contact/AnonymizeTest.php
@@ -2,19 +2,14 @@
 
 namespace Civi\Api4\Action\Contact;
 
-use Civi\Api4\Address;
 use Civi\Api4\Contact;
-use Civi\Api4\Email;
-use Civi\Api4\IM;
-use Civi\Api4\Phone;
-use Civi\Api4\Website;
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Utils\PHPUnit;
-use CRM_RcBase_HeadlessTestCase;
 
 /**
  * @group headless
  */
-class AnonymizeTest extends CRM_RcBase_HeadlessTestCase
+class AnonymizeTest extends HeadlessTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/Civi/Api4/Action/Setting/SmtpConfigTest.php
+++ b/tests/phpunit/Civi/Api4/Action/Setting/SmtpConfigTest.php
@@ -3,14 +3,14 @@
 namespace Civi\Api4\Action\Setting;
 
 use Civi\Api4\Setting;
-use CRM_RcBase_HeadlessTestCase;
+use Civi\RcBase\HeadlessTestCase;
 
 /**
  * Test Get/Set SMTP Config API
  *
  * @group headless
  */
-class SmtpConfigTest extends CRM_RcBase_HeadlessTestCase
+class SmtpConfigTest extends HeadlessTestCase
 {
     public const DEFAULT_SMTP_CONFIG
         = [

--- a/tests/phpunit/Civi/Api4/Action/Setting/SmtpConfigTest.php
+++ b/tests/phpunit/Civi/Api4/Action/Setting/SmtpConfigTest.php
@@ -6,8 +6,6 @@ use Civi\Api4\Setting;
 use Civi\RcBase\HeadlessTestCase;
 
 /**
- * Test Get/Set SMTP Config API
- *
  * @group headless
  */
 class SmtpConfigTest extends HeadlessTestCase

--- a/tests/phpunit/Civi/RcBase/Api4/ActionUtilsTraitTest.php
+++ b/tests/phpunit/Civi/RcBase/Api4/ActionUtilsTraitTest.php
@@ -2,6 +2,8 @@
 
 namespace Civi\RcBase\Api4;
 
+require_once 'Civi/RcBase/Api4/ActionUtilsTrait.php';
+
 use Civi\RcBase\HeadlessTestCase;
 
 /**

--- a/tests/phpunit/Civi/RcBase/Api4/ActionUtilsTraitTest.php
+++ b/tests/phpunit/Civi/RcBase/Api4/ActionUtilsTraitTest.php
@@ -2,14 +2,12 @@
 
 namespace Civi\RcBase\Api4;
 
-require_once 'Civi/RcBase/Api4/ActionUtilsTrait.php';
-
-use CRM_RcBase_HeadlessTestCase;
+use Civi\RcBase\HeadlessTestCase;
 
 /**
  * @group headless
  */
-class ActionUtilsTraitTest extends CRM_RcBase_HeadlessTestCase
+class ActionUtilsTraitTest extends HeadlessTestCase
 {
     use ActionUtilsTrait;
 

--- a/tests/phpunit/Civi/RcBase/ApiWrapper/CreateTest.php
+++ b/tests/phpunit/Civi/RcBase/ApiWrapper/CreateTest.php
@@ -3,16 +3,16 @@
 namespace Civi\RcBase\ApiWrapper;
 
 use Civi\Api4\Contact;
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\APIException;
 use Civi\RcBase\Exception\InvalidArgumentException;
 use Civi\RcBase\Exception\MissingArgumentException;
 use Civi\RcBase\Utils\PHPUnit;
-use CRM_RcBase_HeadlessTestCase;
 
 /**
  * @group headless
  */
-class CreateTest extends CRM_RcBase_HeadlessTestCase
+class CreateTest extends HeadlessTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/Civi/RcBase/ApiWrapper/CreateTest.php
+++ b/tests/phpunit/Civi/RcBase/ApiWrapper/CreateTest.php
@@ -3,10 +3,10 @@
 namespace Civi\RcBase\ApiWrapper;
 
 use Civi\Api4\Contact;
-use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\APIException;
 use Civi\RcBase\Exception\InvalidArgumentException;
 use Civi\RcBase\Exception\MissingArgumentException;
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Utils\PHPUnit;
 
 /**

--- a/tests/phpunit/Civi/RcBase/ApiWrapper/GetTest.php
+++ b/tests/phpunit/Civi/RcBase/ApiWrapper/GetTest.php
@@ -2,17 +2,17 @@
 
 namespace Civi\RcBase\ApiWrapper;
 
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\APIException;
 use Civi\RcBase\Exception\InvalidArgumentException;
 use Civi\RcBase\Utils\DB;
 use Civi\RcBase\Utils\PHPUnit;
 use CRM_Core_BAO_LocationType;
-use CRM_RcBase_HeadlessTestCase;
 
 /**
  * @group headless
  */
-class GetTest extends CRM_RcBase_HeadlessTestCase
+class GetTest extends HeadlessTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/Civi/RcBase/ApiWrapper/GetTest.php
+++ b/tests/phpunit/Civi/RcBase/ApiWrapper/GetTest.php
@@ -2,9 +2,9 @@
 
 namespace Civi\RcBase\ApiWrapper;
 
-use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\APIException;
 use Civi\RcBase\Exception\InvalidArgumentException;
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Utils\DB;
 use Civi\RcBase\Utils\PHPUnit;
 use CRM_Core_BAO_LocationType;

--- a/tests/phpunit/Civi/RcBase/ApiWrapper/RemoveTest.php
+++ b/tests/phpunit/Civi/RcBase/ApiWrapper/RemoveTest.php
@@ -2,9 +2,9 @@
 
 namespace Civi\RcBase\ApiWrapper;
 
-use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\APIException;
 use Civi\RcBase\Exception\InvalidArgumentException;
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Utils\PHPUnit;
 
 /**

--- a/tests/phpunit/Civi/RcBase/ApiWrapper/RemoveTest.php
+++ b/tests/phpunit/Civi/RcBase/ApiWrapper/RemoveTest.php
@@ -2,15 +2,15 @@
 
 namespace Civi\RcBase\ApiWrapper;
 
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\APIException;
 use Civi\RcBase\Exception\InvalidArgumentException;
 use Civi\RcBase\Utils\PHPUnit;
-use CRM_RcBase_HeadlessTestCase;
 
 /**
  * @group headless
  */
-class RemoveTest extends CRM_RcBase_HeadlessTestCase
+class RemoveTest extends HeadlessTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/Civi/RcBase/ApiWrapper/SaveTest.php
+++ b/tests/phpunit/Civi/RcBase/ApiWrapper/SaveTest.php
@@ -2,8 +2,8 @@
 
 namespace Civi\RcBase\ApiWrapper;
 
-use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\APIException;
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Utils\PHPUnit;
 
 /**

--- a/tests/phpunit/Civi/RcBase/ApiWrapper/SaveTest.php
+++ b/tests/phpunit/Civi/RcBase/ApiWrapper/SaveTest.php
@@ -2,14 +2,14 @@
 
 namespace Civi\RcBase\ApiWrapper;
 
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\APIException;
 use Civi\RcBase\Utils\PHPUnit;
-use CRM_RcBase_HeadlessTestCase;
 
 /**
  * @group headless
  */
-class SaveTest extends CRM_RcBase_HeadlessTestCase
+class SaveTest extends HeadlessTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/Civi/RcBase/ApiWrapper/UpdateTest.php
+++ b/tests/phpunit/Civi/RcBase/ApiWrapper/UpdateTest.php
@@ -3,17 +3,17 @@
 namespace Civi\RcBase\ApiWrapper;
 
 use Civi\Api4\Contact;
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\APIException;
 use Civi\RcBase\Exception\InvalidArgumentException;
 use Civi\RcBase\Exception\MissingArgumentException;
 use Civi\RcBase\Utils\PHPUnit;
 use CRM_RcBase_Api_Get;
-use CRM_RcBase_HeadlessTestCase;
 
 /**
  * @group headless
  */
-class UpdateTest extends CRM_RcBase_HeadlessTestCase
+class UpdateTest extends HeadlessTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/Civi/RcBase/ApiWrapper/UpdateTest.php
+++ b/tests/phpunit/Civi/RcBase/ApiWrapper/UpdateTest.php
@@ -3,10 +3,10 @@
 namespace Civi\RcBase\ApiWrapper;
 
 use Civi\Api4\Contact;
-use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\APIException;
 use Civi\RcBase\Exception\InvalidArgumentException;
 use Civi\RcBase\Exception\MissingArgumentException;
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Utils\PHPUnit;
 use CRM_RcBase_Api_Get;
 

--- a/tests/phpunit/Civi/RcBase/ExceptionTest.php
+++ b/tests/phpunit/Civi/RcBase/ExceptionTest.php
@@ -2,14 +2,14 @@
 
 namespace Civi\RcBase\Exception;
 
+use Civi\RcBase\HeadlessTestCase;
 use CRM_Core_Error;
 use CRM_Core_Exception;
-use CRM_RcBase_HeadlessTestCase;
 
 /**
  * @group headless
  */
-class ExceptionTest extends CRM_RcBase_HeadlessTestCase
+class ExceptionTest extends HeadlessTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/Civi/RcBase/HeadlessTestCase.php
+++ b/tests/phpunit/Civi/RcBase/HeadlessTestCase.php
@@ -26,17 +26,9 @@ class HeadlessTestCase extends TestCase implements HeadlessInterface
     }
 
     /**
-     * The setupHeadless function runs at the start of each test case, right before
-     * the headless environment reboots.
-     * It should perform any necessary steps required for putting the database
-     * in a consistent baseline -- such as loading schema and extensions.
-     * The utility `\Civi\Test::headless()` provides a number of helper functions
-     * for managing this setup, and it includes optimizations to avoid redundant
-     * setup work.
-     *
-     * @see \Civi\Test
+     * @return void
      */
-    public function setUpHeadless()
+    public function setUpHeadless(): void
     {
     }
 }

--- a/tests/phpunit/Civi/RcBase/HeadlessTestCase.php
+++ b/tests/phpunit/Civi/RcBase/HeadlessTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Civi\RcBase;
+
 use Civi\Test;
 use Civi\Test\HeadlessInterface;
 use PHPUnit\Framework\TestCase;
@@ -7,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Base headless Test Case
  */
-class CRM_RcBase_HeadlessTestCase extends TestCase implements HeadlessInterface
+class HeadlessTestCase extends TestCase implements HeadlessInterface
 {
     /**
      * Apply a forced rebuild of DB, thus

--- a/tests/phpunit/Civi/RcBase/HeadlessTestCase.php
+++ b/tests/phpunit/Civi/RcBase/HeadlessTestCase.php
@@ -7,7 +7,7 @@ use Civi\Test\HeadlessInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Base headless Test Case
+ * @group headless
  */
 class HeadlessTestCase extends TestCase implements HeadlessInterface
 {

--- a/tests/phpunit/Civi/RcBase/IOProcessor/BaseTest.php
+++ b/tests/phpunit/Civi/RcBase/IOProcessor/BaseTest.php
@@ -2,9 +2,9 @@
 
 namespace Civi\RcBase\IOProcessor;
 
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\InvalidArgumentException;
 use Civi\RcBase\Exception\MissingArgumentException;
-use CRM_RcBase_HeadlessTestCase;
 use Throwable;
 
 /**
@@ -12,7 +12,7 @@ use Throwable;
  *
  * @group headless
  */
-class BaseTest extends CRM_RcBase_HeadlessTestCase
+class BaseTest extends HeadlessTestCase
 {
     /**
      * Content types

--- a/tests/phpunit/Civi/RcBase/IOProcessor/BaseTest.php
+++ b/tests/phpunit/Civi/RcBase/IOProcessor/BaseTest.php
@@ -2,9 +2,9 @@
 
 namespace Civi\RcBase\IOProcessor;
 
-use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\InvalidArgumentException;
 use Civi\RcBase\Exception\MissingArgumentException;
+use Civi\RcBase\HeadlessTestCase;
 use Throwable;
 
 /**
@@ -154,7 +154,7 @@ class BaseTest extends HeadlessTestCase
             'UTF-8' => 'kéményŐÜÖÓúőü$!#~`\\|',
         ];
         $expected = [
-            "hello" => 'this is a test',
+            'hello' => 'this is a test',
             'sub_array' => [
                 'first',
                 'se cond',

--- a/tests/phpunit/Civi/RcBase/IOProcessor/BaseTest.php
+++ b/tests/phpunit/Civi/RcBase/IOProcessor/BaseTest.php
@@ -8,8 +8,6 @@ use Civi\RcBase\Exception\MissingArgumentException;
 use Throwable;
 
 /**
- * Test Base Processor class
- *
  * @group headless
  */
 class BaseTest extends HeadlessTestCase

--- a/tests/phpunit/Civi/RcBase/IOProcessor/ConfigTest.php
+++ b/tests/phpunit/Civi/RcBase/IOProcessor/ConfigTest.php
@@ -2,15 +2,15 @@
 
 namespace Civi\RcBase\IOProcessor;
 
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\InvalidArgumentException;
-use CRM_RcBase_HeadlessTestCase;
 
 /**
  * Test Config Processor class
  *
  * @group headless
  */
-class ConfigTest extends CRM_RcBase_HeadlessTestCase
+class ConfigTest extends HeadlessTestCase
 {
     /**
      * @return array[]

--- a/tests/phpunit/Civi/RcBase/IOProcessor/ConfigTest.php
+++ b/tests/phpunit/Civi/RcBase/IOProcessor/ConfigTest.php
@@ -2,8 +2,8 @@
 
 namespace Civi\RcBase\IOProcessor;
 
-use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\InvalidArgumentException;
+use Civi\RcBase\HeadlessTestCase;
 
 /**
  * @group headless

--- a/tests/phpunit/Civi/RcBase/IOProcessor/ConfigTest.php
+++ b/tests/phpunit/Civi/RcBase/IOProcessor/ConfigTest.php
@@ -6,8 +6,6 @@ use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\InvalidArgumentException;
 
 /**
- * Test Config Processor class
- *
  * @group headless
  */
 class ConfigTest extends HeadlessTestCase

--- a/tests/phpunit/Civi/RcBase/IOProcessor/JSONTest.php
+++ b/tests/phpunit/Civi/RcBase/IOProcessor/JSONTest.php
@@ -7,8 +7,6 @@ use Civi\RcBase\Exception\InvalidArgumentException;
 use Civi\RcBase\Exception\RunTimeException;
 
 /**
- * Test JSON Processor class
- *
  * @group headless
  */
 class JSONTest extends HeadlessTestCase

--- a/tests/phpunit/Civi/RcBase/IOProcessor/JSONTest.php
+++ b/tests/phpunit/Civi/RcBase/IOProcessor/JSONTest.php
@@ -2,16 +2,16 @@
 
 namespace Civi\RcBase\IOProcessor;
 
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\InvalidArgumentException;
 use Civi\RcBase\Exception\RunTimeException;
-use CRM_RcBase_HeadlessTestCase;
 
 /**
  * Test JSON Processor class
  *
  * @group headless
  */
-class JSONTest extends CRM_RcBase_HeadlessTestCase
+class JSONTest extends HeadlessTestCase
 {
     /**
      * Provide valid JSON

--- a/tests/phpunit/Civi/RcBase/IOProcessor/JSONTest.php
+++ b/tests/phpunit/Civi/RcBase/IOProcessor/JSONTest.php
@@ -2,9 +2,9 @@
 
 namespace Civi\RcBase\IOProcessor;
 
-use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\InvalidArgumentException;
 use Civi\RcBase\Exception\RunTimeException;
+use Civi\RcBase\HeadlessTestCase;
 
 /**
  * @group headless

--- a/tests/phpunit/Civi/RcBase/IOProcessor/UrlEncodedFormTest.php
+++ b/tests/phpunit/Civi/RcBase/IOProcessor/UrlEncodedFormTest.php
@@ -5,8 +5,6 @@ namespace Civi\RcBase\IOProcessor;
 use Civi\RcBase\HeadlessTestCase;
 
 /**
- * Test URL encoded form Processor class
- *
  * @group headless
  */
 class UrlEncodedFormTest extends HeadlessTestCase

--- a/tests/phpunit/Civi/RcBase/IOProcessor/UrlEncodedFormTest.php
+++ b/tests/phpunit/Civi/RcBase/IOProcessor/UrlEncodedFormTest.php
@@ -2,14 +2,14 @@
 
 namespace Civi\RcBase\IOProcessor;
 
-use CRM_RcBase_HeadlessTestCase;
+use Civi\RcBase\HeadlessTestCase;
 
 /**
  * Test URL encoded form Processor class
  *
  * @group headless
  */
-class UrlEncodedFormTest extends CRM_RcBase_HeadlessTestCase
+class UrlEncodedFormTest extends HeadlessTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/Civi/RcBase/IOProcessor/XMLTest.php
+++ b/tests/phpunit/Civi/RcBase/IOProcessor/XMLTest.php
@@ -7,8 +7,6 @@ use Civi\RcBase\Exception\InvalidArgumentException;
 use SimpleXMLElement;
 
 /**
- * Test XML Processor class
- *
  * @group headless
  */
 class XMLTest extends HeadlessTestCase

--- a/tests/phpunit/Civi/RcBase/IOProcessor/XMLTest.php
+++ b/tests/phpunit/Civi/RcBase/IOProcessor/XMLTest.php
@@ -2,8 +2,8 @@
 
 namespace Civi\RcBase\IOProcessor;
 
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\InvalidArgumentException;
-use CRM_RcBase_HeadlessTestCase;
 use SimpleXMLElement;
 
 /**
@@ -11,7 +11,7 @@ use SimpleXMLElement;
  *
  * @group headless
  */
-class XMLTest extends CRM_RcBase_HeadlessTestCase
+class XMLTest extends HeadlessTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/Civi/RcBase/IOProcessor/XMLTest.php
+++ b/tests/phpunit/Civi/RcBase/IOProcessor/XMLTest.php
@@ -2,8 +2,8 @@
 
 namespace Civi\RcBase\IOProcessor;
 
-use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\InvalidArgumentException;
+use Civi\RcBase\HeadlessTestCase;
 use SimpleXMLElement;
 
 /**

--- a/tests/phpunit/Civi/RcBase/SettingsTest.php
+++ b/tests/phpunit/Civi/RcBase/SettingsTest.php
@@ -19,7 +19,7 @@ class SettingsTest extends HeadlessTestCase
     public function provideSettings(): array
     {
         $object = new stdClass();
-        $object->property = "value";
+        $object->property = 'value';
 
         return [
             'string' => ['some string'],

--- a/tests/phpunit/Civi/RcBase/SettingsTest.php
+++ b/tests/phpunit/Civi/RcBase/SettingsTest.php
@@ -6,13 +6,12 @@ use API_Exception;
 use Civi;
 use Civi\Api4\Setting;
 use Civi\RcBase\Exception\MissingArgumentException;
-use CRM_RcBase_HeadlessTestCase;
 use stdClass;
 
 /**
  * @group headless
  */
-class SettingsTest extends CRM_RcBase_HeadlessTestCase
+class SettingsTest extends HeadlessTestCase
 {
     /**
      * @return array

--- a/tests/phpunit/Civi/RcBase/Utils/ArraysTest.php
+++ b/tests/phpunit/Civi/RcBase/Utils/ArraysTest.php
@@ -2,14 +2,12 @@
 
 namespace Civi\RcBase\Utils;
 
-use PHPUnit\Framework\TestCase;
-
-require_once 'Civi/RcBase/Utils/Arrays.php';
+use CRM_RcBase_HeadlessTestCase;
 
 /**
- * @group unit
+ * @group headless
  */
-class ArraysTest extends TestCase
+class ArraysTest extends CRM_RcBase_HeadlessTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/Civi/RcBase/Utils/ArraysTest.php
+++ b/tests/phpunit/Civi/RcBase/Utils/ArraysTest.php
@@ -2,12 +2,12 @@
 
 namespace Civi\RcBase\Utils;
 
-use CRM_RcBase_HeadlessTestCase;
+use Civi\RcBase\HeadlessTestCase;
 
 /**
  * @group headless
  */
-class ArraysTest extends CRM_RcBase_HeadlessTestCase
+class ArraysTest extends HeadlessTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/Civi/RcBase/Utils/DBTest.php
+++ b/tests/phpunit/Civi/RcBase/Utils/DBTest.php
@@ -6,9 +6,9 @@ use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\GroupContact;
 use Civi\RcBase\ApiWrapper\Create;
-use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\DataBaseException;
 use Civi\RcBase\Exception\MissingArgumentException;
+use Civi\RcBase\HeadlessTestCase;
 use CRM_Contact_BAO_Contact;
 
 /**

--- a/tests/phpunit/Civi/RcBase/Utils/DBTest.php
+++ b/tests/phpunit/Civi/RcBase/Utils/DBTest.php
@@ -6,15 +6,15 @@ use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\GroupContact;
 use Civi\RcBase\ApiWrapper\Create;
+use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Exception\DataBaseException;
 use Civi\RcBase\Exception\MissingArgumentException;
 use CRM_Contact_BAO_Contact;
-use CRM_RcBase_HeadlessTestCase;
 
 /**
  * @group headless
  */
-class DBTest extends CRM_RcBase_HeadlessTestCase
+class DBTest extends HeadlessTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/Civi/RcBase/Utils/FileTest.php
+++ b/tests/phpunit/Civi/RcBase/Utils/FileTest.php
@@ -2,12 +2,12 @@
 
 namespace Civi\RcBase\Utils;
 
-use CRM_RcBase_HeadlessTestCase;
+use Civi\RcBase\HeadlessTestCase;
 
 /**
  * @group headless
  */
-class FileTest extends CRM_RcBase_HeadlessTestCase
+class FileTest extends HeadlessTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/Civi/RcBase/Utils/PHPUnitTest.php
+++ b/tests/phpunit/Civi/RcBase/Utils/PHPUnitTest.php
@@ -3,14 +3,14 @@
 namespace Civi\RcBase\Utils;
 
 use Civi\Api4\Email;
+use Civi\RcBase\HeadlessTestCase;
 use CRM_Core_Session;
 use CRM_RcBase_Api_Get;
-use CRM_RcBase_HeadlessTestCase;
 
 /**
  * @group headless
  */
-class PHPUnitTest extends CRM_RcBase_HeadlessTestCase
+class PHPUnitTest extends HeadlessTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/Civi/RcBase/Utils/UITest.php
+++ b/tests/phpunit/Civi/RcBase/Utils/UITest.php
@@ -2,12 +2,12 @@
 
 namespace Civi\RcBase\Utils;
 
-use CRM_RcBase_HeadlessTestCase;
+use Civi\RcBase\HeadlessTestCase;
 
 /**
  * @group headless
  */
-class UITest extends CRM_RcBase_HeadlessTestCase
+class UITest extends HeadlessTestCase
 {
     /**
      * @return void

--- a/tests/phpunit/api/v3/Extension/HaspendingupgradeTest.php
+++ b/tests/phpunit/api/v3/Extension/HaspendingupgradeTest.php
@@ -3,8 +3,6 @@
 use Civi\RcBase\HeadlessTestCase;
 
 /**
- * Extension.Haspendingupgrade API Test Case
- *
  * @group headless
  */
 class api_v3_Extension_HaspendingupgradeTest extends HeadlessTestCase

--- a/tests/phpunit/api/v3/Extension/HaspendingupgradeTest.php
+++ b/tests/phpunit/api/v3/Extension/HaspendingupgradeTest.php
@@ -1,11 +1,13 @@
 <?php
 
+use Civi\RcBase\HeadlessTestCase;
+
 /**
  * Extension.Haspendingupgrade API Test Case
  *
  * @group headless
  */
-class api_v3_Extension_HaspendingupgradeTest extends CRM_RcBase_HeadlessTestCase
+class api_v3_Extension_HaspendingupgradeTest extends HeadlessTestCase
 {
     /**
      * @throws \CiviCRM_API3_Exception


### PR DESCRIPTION
- all test inherit single `HeadlessTestCase`
- remove `tearDown`
- rename `*HeadlessTest` to `*Test`
- move `HeadlessTestCase` to `\Civi` namespace
- standardize `setUpHeadless()` docblock
- test class docblock: keep only `@group headless`
- remove unused `HookInterface`, `TransactionalInterface`; if needed add only relevant test cases
