### PR TITLE
ApiWrapper\Remove::contactFromGroup add status 'Removed' when no records present

### DIFF
--- a/Civi/RcBase/ApiWrapper/Remove.php
+++ b/Civi/RcBase/ApiWrapper/Remove.php
@@ -121,6 +121,14 @@ class Remove
 
         switch ($status) {
             case Get::GROUP_CONTACT_STATUS_NONE:
+                $values = [
+                    'group_id' => $group_id,
+                    'contact_id' => $contact_id,
+                    'status' => 'Removed',
+                ];
+                Create::entity('GroupContact', $values, $check_permissions);
+
+                return 1;
             case Get::GROUP_CONTACT_STATUS_REMOVED:
                 return 0;
             case Get::GROUP_CONTACT_STATUS_PENDING:

--- a/info.xml
+++ b/info.xml
@@ -17,8 +17,8 @@
         <url desc="Support">https://github.com/reflexive-communications/rc-base/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2023-03-21</releaseDate>
-    <version>1.36.0</version>
+    <releaseDate>2023-05-02</releaseDate>
+    <version>1.36.1</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.48</ver>

--- a/tests/phpunit/Civi/RcBase/ApiWrapper/RemoveTest.php
+++ b/tests/phpunit/Civi/RcBase/ApiWrapper/RemoveTest.php
@@ -68,8 +68,8 @@ class RemoveTest extends HeadlessTestCase
         $contact_id = PHPUnit::createIndividual();
 
         // Remove not added contact
-        self::assertSame(0, Remove::contactFromGroup($contact_id, $group_id), 'Wrong number of affected contacts (not added)');
-        self::assertSame(Get::GROUP_CONTACT_STATUS_NONE, Get::groupContactStatus($contact_id, $group_id), 'Failed to remove contact (not added)');
+        self::assertSame(1, Remove::contactFromGroup($contact_id, $group_id), 'Wrong number of affected contacts (not added)');
+        self::assertSame(Get::GROUP_CONTACT_STATUS_REMOVED, Get::groupContactStatus($contact_id, $group_id), 'Failed to remove contact (not added)');
         // Add to group then remove
         $group_contact_id = Save::addContactToGroup($contact_id, $group_id);
         self::assertSame(1, Remove::contactFromGroup($contact_id, $group_id), 'Wrong number of affected contacts (added)');


### PR DESCRIPTION
So it supports now removing contacts manually from smart groups.