### PR TITLE
ApiWrapper group contact methods supports smart groups

### DIFF
--- a/Civi/RcBase/ApiWrapper/Get.php
+++ b/Civi/RcBase/ApiWrapper/Get.php
@@ -5,6 +5,8 @@ namespace Civi\RcBase\ApiWrapper;
 use Civi\Api4\Generic\Result;
 use Civi\RcBase\Exception\APIException;
 use Civi\RcBase\Exception\InvalidArgumentException;
+use Civi\RcBase\Utils\DB;
+use CRM_Contact_BAO_GroupContactCache;
 use Throwable;
 
 /**
@@ -303,12 +305,15 @@ class Get
      * @param int $contact_id Contact ID
      * @param int $group_id Group ID
      * @param bool $check_permissions Should we check permissions (ACLs)?
+     * @param bool $smart_group Check group_contact_cache also
      *
      * @return int Status code
      * @throws \Civi\RcBase\Exception\APIException
      * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\DataBaseException
+     * @todo Change signature in v2
      */
-    public static function groupContactStatus(int $contact_id, int $group_id, bool $check_permissions = false): int
+    public static function groupContactStatus(int $contact_id, int $group_id, bool $check_permissions = false, bool $smart_group = false): int
     {
         if ($contact_id < 1 || $group_id < 1) {
             throw new InvalidArgumentException('ID');
@@ -333,7 +338,23 @@ class Get
             case 'Pending':
                 return self::GROUP_CONTACT_STATUS_PENDING;
             case null:
-                return self::GROUP_CONTACT_STATUS_NONE;
+                // Skip checking smart groups
+                if (!$smart_group) {
+                    return self::GROUP_CONTACT_STATUS_NONE;
+                }
+
+                // Regenerate cache if expired
+                CRM_Contact_BAO_GroupContactCache::check([$group_id]);
+                $sql = 'SELECT contact_id
+                        FROM civicrm_group_contact_cache
+                        WHERE contact_id = %1 AND group_id = %2
+                        LIMIT 1';
+                $group_contact_cache = DB::query($sql, [
+                    1 => [$contact_id, 'Positive'],
+                    2 => [$group_id, 'Positive'],
+                ]);
+
+                return empty($group_contact_cache) ? self::GROUP_CONTACT_STATUS_NONE : self::GROUP_CONTACT_STATUS_ADDED;
             default:
                 throw new APIException('GroupContact', 'get', "Invalid status returned: {$status}");
         }

--- a/Civi/RcBase/ApiWrapper/Save.php
+++ b/Civi/RcBase/ApiWrapper/Save.php
@@ -3,6 +3,8 @@
 namespace Civi\RcBase\ApiWrapper;
 
 use Civi\RcBase\Exception\APIException;
+use Civi\RcBase\Utils\DB;
+use CRM_Contact_BAO_GroupContactCache;
 
 /**
  * Common Save Actions
@@ -62,13 +64,16 @@ class Save
      * @param int $contact_id Contact ID
      * @param int $group_id Group ID
      * @param bool $check_permissions Should we check permissions (ACLs)?
+     * @param bool $smart_group Update group_contact_cache also
      *
      * @return int Group contact ID
      * @throws \Civi\RcBase\Exception\APIException
      * @throws \Civi\RcBase\Exception\InvalidArgumentException
      * @throws \Civi\RcBase\Exception\MissingArgumentException
+     * @throws \Civi\RcBase\Exception\DataBaseException
+     * @todo Change signature in v2
      */
-    public static function addContactToGroup(int $contact_id, int $group_id, bool $check_permissions = false): int
+    public static function addContactToGroup(int $contact_id, int $group_id, bool $check_permissions = false, bool $smart_group = false): int
     {
         $status = Get::groupContactStatus($contact_id, $group_id, $check_permissions);
 
@@ -107,6 +112,28 @@ class Save
                 break;
             default:
                 throw new APIException('GroupContact', 'get', "Invalid status returned: {$status}");
+        }
+
+        // Update cache manually if cache is not expired yet --> so cache will be accurate even until regeneration
+        if ($smart_group && CRM_Contact_BAO_GroupContactCache::check([$group_id])) {
+            // Check record present
+            $sql = 'SELECT contact_id
+                    FROM civicrm_group_contact_cache
+                    WHERE contact_id = %1 AND group_id = %2
+                    LIMIT 1';
+            $group_contact_cache = DB::query($sql, [
+                1 => [$contact_id, 'Positive'],
+                2 => [$group_id, 'Positive'],
+            ]);
+
+            // Add to cache
+            if (empty($group_contact_cache)) {
+                $sql = 'INSERT INTO civicrm_group_contact_cache (id, group_id, contact_id) VALUES (NULL, %2, %1)';
+                DB::query($sql, [
+                    1 => [$contact_id, 'Positive'],
+                    2 => [$group_id, 'Positive'],
+                ]);
+            }
         }
 
         return $group_contact_id;

--- a/info.xml
+++ b/info.xml
@@ -17,8 +17,8 @@
         <url desc="Support">https://github.com/reflexive-communications/rc-base/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2023-05-02</releaseDate>
-    <version>1.36.1</version>
+    <releaseDate>2023-05-03</releaseDate>
+    <version>1.36.2</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.48</ver>

--- a/tests/phpunit/Civi/RcBase/ApiWrapper/GetTest.php
+++ b/tests/phpunit/Civi/RcBase/ApiWrapper/GetTest.php
@@ -7,6 +7,7 @@ use Civi\RcBase\Exception\InvalidArgumentException;
 use Civi\RcBase\HeadlessTestCase;
 use Civi\RcBase\Utils\DB;
 use Civi\RcBase\Utils\PHPUnit;
+use CRM_Contact_BAO_GroupContactCache;
 use CRM_Core_BAO_LocationType;
 
 /**
@@ -286,7 +287,7 @@ class GetTest extends HeadlessTestCase
      * @throws \Civi\RcBase\Exception\InvalidArgumentException
      * @throws \Civi\RcBase\Exception\MissingArgumentException
      */
-    public function testGroupContactStatus()
+    public function testGroupContactStatusWithNormalGroup()
     {
         // Create group, contact
         $group_data = ['title' => 'Group contact test group'];
@@ -311,6 +312,76 @@ class GetTest extends HeadlessTestCase
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('Invalid ID');
         Get::groupContactStatus(-1, -1);
+    }
+
+    /**
+     * @return void
+     * @throws \CRM_Core_Exception
+     * @throws \Civi\RcBase\Exception\APIException
+     * @throws \Civi\RcBase\Exception\InvalidArgumentException
+     * @throws \Civi\RcBase\Exception\MissingArgumentException
+     */
+    public function testGroupContactStatusWithSmartGroup()
+    {
+        // Create smart groups, contact
+        $saved_search_id_all = Create::entity('SavedSearch');
+        $saved_search_id_nobody = Create::entity('SavedSearch', [
+            'api_entity' => 'Contact',
+            'api_params' => [
+                'version' => 4,
+                'where' => [['first_name', '=', 'nobody']],
+            ],
+        ]);
+        $group_id_all = Create::group([
+            'title' => 'Smart group with all contacts',
+            'saved_search_id' => $saved_search_id_all,
+        ]);
+        $group_id_nobody = Create::group([
+            'title' => 'Smart group with no contacts',
+            'saved_search_id' => $saved_search_id_nobody,
+        ]);
+        $contact_id = PHPUnit::createIndividual();
+
+        // Check new contact not in group
+        $groups_cache = CRM_Contact_BAO_GroupContactCache::contactGroup($contact_id);
+        self::assertCount(1, $groups_cache['group'], 'Contact not in single smart group');
+        self::assertEquals($group_id_all, $groups_cache['group'][0]['id'], 'Contact in wrong smart group');
+        self::assertSame(Get::GROUP_CONTACT_STATUS_NONE, Get::groupContactStatus($contact_id, $group_id_nobody, false, true), 'Wrong value returned for new contact when contact not in group');
+
+        // Check new contact (added to group by search)
+        $groups_cache = CRM_Contact_BAO_GroupContactCache::contactGroup($contact_id);
+        self::assertCount(1, $groups_cache['group'], 'Contact not in single smart group');
+        self::assertEquals($group_id_all, $groups_cache['group'][0]['id'], 'Contact in wrong smart group');
+        self::assertSame(Get::GROUP_CONTACT_STATUS_ADDED, Get::groupContactStatus($contact_id, $group_id_all, false, true), 'Wrong value returned for new contact when contact in group');
+
+        // Add contact to group manually
+        $group_contact_id = Create::entity('GroupContact', ['group_id' => $group_id_all, 'contact_id' => $contact_id]);
+        CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($group_id_all);
+        $groups_cache = CRM_Contact_BAO_GroupContactCache::contactGroup($contact_id);
+        self::assertCount(1, $groups_cache['group'], 'Contact not in single smart group');
+        self::assertEquals($group_id_all, $groups_cache['group'][0]['id'], 'Contact in wrong smart group');
+        self::assertSame(Get::GROUP_CONTACT_STATUS_ADDED, Get::groupContactStatus($contact_id, $group_id_all, false, true), 'Wrong value returned for added contact');
+
+        // Set to pending
+        Update::entity('GroupContact', $group_contact_id, ['status' => 'Pending']);
+        CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($group_id_all);
+        $groups_cache = CRM_Contact_BAO_GroupContactCache::contactGroup($contact_id);
+        self::assertCount(1, $groups_cache['group'], 'Contact not in single smart group');
+        self::assertEquals($group_id_all, $groups_cache['group'][0]['id'], 'Contact in wrong smart group');
+        self::assertSame(Get::GROUP_CONTACT_STATUS_PENDING, Get::groupContactStatus($contact_id, $group_id_all, false, true), 'Wrong value returned for pending contact');
+
+        // Remove contact
+        Update::entity('GroupContact', $group_contact_id, ['status' => 'Removed']);
+        CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($group_id_all);
+        $groups_cache = CRM_Contact_BAO_GroupContactCache::contactGroup($contact_id);
+        self::assertSame([], $groups_cache, 'Contact not removed from smart group');
+        self::assertSame(Get::GROUP_CONTACT_STATUS_REMOVED, Get::groupContactStatus($contact_id, $group_id_all, false, true), 'Wrong value returned for removed contact');
+
+        // Check invalid status
+        Update::entity('GroupContact', $group_contact_id, ['status' => 'invalid']);
+        self::expectException(APIException::class);
+        self::expectExceptionMessage('Invalid status returned');
+        Get::groupContactStatus($contact_id, $group_id_all);
     }
 
     /**


### PR DESCRIPTION
- `ApiWrapper\Get::groupContactStatus()` check smart groups also (if prompted with `$smart_group=true` parameter)
- `ApiWrapper\Save::addContactToGroup()` and `Remove::contactFromGroup()` update group_contact_cache also so cache will be accurate even if not yet regenerated